### PR TITLE
fix: add apl-keycloak-operator namespace

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -47,6 +47,8 @@ k8s:
       app: jaeger
       disableIstioInjection: true
     - name: keycloak
+    - name: apl-keycloak-operator
+      disableIstioInjection: true
     - name: kiali
       app: kiali
     - name: kiali-operator


### PR DESCRIPTION
### Description:
This PR adds `apl-keycloak-operator` namespace.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
