### PR TITLE
fix: apl keycloak operator tls

### DIFF
--- a/charts/apl-keycloak-operator/templates/deployment.yaml
+++ b/charts/apl-keycloak-operator/templates/deployment.yaml
@@ -42,10 +42,12 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if and .Values.configs (not (empty .Values.configs.tls.certificates)) }}
           volumeMounts:
           - name: tls-certs
             mountPath: /app/config/tls/certificate.crt
             subPath: certificate.crt
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -59,9 +61,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+          {{- if and .Values.configs (not (empty .Values.configs.tls.certificates)) }}
           - name: tls-certs
             secret:
               secretName: keycloak-operator-tls-certs-cm
+          {{- end }}
           - name: operator-config-kc
             configMap:
               name: apl-keycloak-operator-cm

--- a/charts/apl-keycloak-operator/templates/deployment.yaml
+++ b/charts/apl-keycloak-operator/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if and .Values.configs (not (empty .Values.configs.tls.certificates)) }}
+          {{- if (not (empty .Values.configs.tls.certificates)) }}
           command: ['/bin/sh', '-c']
           args: ['export NODE_EXTRA_CA_CERTS=/app/config/tls/certificate.crt && npm run operator:keycloak']
           env:
@@ -42,7 +42,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if and .Values.configs (not (empty .Values.configs.tls.certificates)) }}
+          {{- if (not (empty .Values.configs.tls.certificates)) }}
           volumeMounts:
           - name: tls-certs
             mountPath: /app/config/tls/certificate.crt
@@ -61,7 +61,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-          {{- if and .Values.configs (not (empty .Values.configs.tls.certificates)) }}
+          {{- if (not (empty .Values.configs.tls.certificates)) }}
           - name: tls-certs
             secret:
               secretName: keycloak-operator-tls-certs-cm

--- a/charts/apl-keycloak-operator/templates/secrets.yaml
+++ b/charts/apl-keycloak-operator/templates/secrets.yaml
@@ -1,9 +1,9 @@
-{{- with .Values.configs.tls.certificates.caCert }}
+{{- if and .Values.configs .Values.configs.tls .Values.configs.tls.certificates .Values.configs.tls.certificates.caCert }}
 apiVersion: v1
 kind: Secret
 metadata:
     name: keycloak-operator-tls-certs-cm
     namespace: apl-keycloak-operator
 data:
-  certificate.crt: {{- . | b64enc | nindent 4 }}
+  certificate.crt: {{- .Values.configs.tls.certificates.caCert | b64enc | nindent 4 }}
 {{- end }}

--- a/values/apl-keycloak-operator/apl-keycloak-operator.gotmpl
+++ b/values/apl-keycloak-operator/apl-keycloak-operator.gotmpl
@@ -12,12 +12,14 @@ imagePullSecrets:
   - name: apl-pullsecret-global
 {{- end }}
 configs:
-  {{ if $v._derived.untrustedCA }}
   tls:
     certificates:
+    {{ if $v._derived.untrustedCA }}
       caCert: |
         {{- $v._derived.caCert | nindent 8 }}
-  {{ end }}
+    {{- else }}
+      {}
+{{ end }}
 script: |
   {{- if $v._derived.untrustedCA }}
   export NODE_EXTRA_CA_CERTS=/app/config/tls/certificates.crt


### PR DESCRIPTION
This PR will apply the following changes:
- extra check for untrustedCa for volumemount and volume on apl-keycloak-operator
- fix for apl-keycloak-operator secrets.yaml, now it doesn't throw a nil error on the tls object