### PR TITLE
fix: derived

### DIFF
--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -85,7 +85,6 @@ environments:
               credentials:
                 password: {{ $a | get "harbor.registry.credentials.password" $v.otomi.adminPassword }}
           gitea:
-            enabled: {{ and (eq $droneProvider "gitea") (eq ($a | get "drone.sourceControl.gitea.server" $giteaUrl) $giteaUrl) }}
             adminPassword: {{ $a | get "gitea.adminPassword" $v.otomi.adminPassword }}
           keycloak:
             enabled: true
@@ -93,6 +92,8 @@ environments:
             adminPassword: {{ $a | get "keycloak.adminPassword" $v.otomi.adminPassword }}
           metrics-server:
             enabled: {{ $a | get "metrics-server.enabled" (has $provider (list "custom" "aws" "digitalocean" "linode")) }}
+          minio:
+            enabled: {{ eq $obj.type "minioLocal" }}
           prometheus-msteams:
             enabled: {{ and ($a | get "alertmanager.enabled" false) (or (has "msteams" ($v | get "alerts.receivers" list)) (has "msteams" ($v | get "home.receivers" list))) }}
         ingress:

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -2,7 +2,7 @@
 {{- $a := $v.apps }}
 {{- $k := $a | get "keycloak" dict }}
 {{- $o := $v | get "oidc" dict }}
-
+{{- $obj := $v.obj.provider }}
 {{- $cm := index $v.apps "cert-manager" }}
 {{- $versions := (readFile "../versions.yaml" | fromYaml) }}
 {{- $pkgVersion := (readFile "../package.json") | regexFind "\"version\": \"([0-9.]+)\"" | regexFind "[0-9]+.[0-9]+.[0-9]+" }}


### PR DESCRIPTION
This PR:

- enables minio when obj is configured for `minioLocal`
- removes the `$v.apps.gitea.enabled` logic because Gitea is always enabled
