### PR TITLE
fix: sni hosts

### DIFF
--- a/charts/team-ns/templates/istio-virtualservices.yaml
+++ b/charts/team-ns/templates/istio-virtualservices.yaml
@@ -194,7 +194,8 @@ spec:
     - match:
         - port: 443
           sniHosts:
-            - '*'
+            - {{ $domain }}
+            - {{ $s.cname.domain }}
       route:
         - destination:
             host: {{ $svc }}.{{ $ns }}.svc.cluster.local


### PR DESCRIPTION
This PR fixes the wrong `*` sniHosts when a `CNAME` is used. Using `*` is not supported anymore so we need to set the hosts
