### PR TITLE
fix: loki auth for multi-tenancy

### DIFF
--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -198,19 +198,11 @@ loki:
       tail_proxy_url: http://{{ include "loki.querierFullname" . }}:3100
 
     compactor:
+      {{- if eq .Values.loki.storageConfig.boltdb_shipper.shared_store "s3" }}
+      shared_store: s3
+      {{- else }}
       shared_store: filesystem
-
-    ruler:
-      storage:
-        type: local
-        local:
-          directory: /etc/loki/rules
-      ring:
-        kvstore:
-          store: memberlist
-      rule_path: /tmp/loki/scratch
-      alertmanager_url: https://alertmanager.xx
-      external_url: https://alertmanager.xx
+      {{- end }}
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig:

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -79,10 +79,13 @@ loki:
   server:
     # -- HTTP server listen port
     http_listen_port: 3100
+  # Enables authentication through the X-Scope-OrgID header, which must be present
+  # if true. If false, the OrgID will always be set to 'fake'
+  auth_enabled: false
   # -- Config file contents for Loki
   # @default -- See values.yaml
   config: |
-    auth_enabled: true
+    auth_enabled: {{ .Values.loki.auth_enabled }}
 
     server:
       {{- toYaml .Values.loki.server | nindent 6 }}

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -79,13 +79,10 @@ loki:
   server:
     # -- HTTP server listen port
     http_listen_port: 3100
-  # Enables authentication through the X-Scope-OrgID header, which must be present
-  # if true. If false, the OrgID will always be set to 'fake'
-  auth_enabled: false
   # -- Config file contents for Loki
   # @default -- See values.yaml
   config: |
-    auth_enabled: {{ .Values.loki.auth_enabled }}
+    auth_enabled: false
 
     server:
       {{- toYaml .Values.loki.server | nindent 6 }}
@@ -198,11 +195,19 @@ loki:
       tail_proxy_url: http://{{ include "loki.querierFullname" . }}:3100
 
     compactor:
-      {{- if eq .Values.loki.storageConfig.boltdb_shipper.shared_store "s3" }}
-      shared_store: s3
-      {{- else }}
       shared_store: filesystem
-      {{- end }}
+
+    ruler:
+      storage:
+        type: local
+        local:
+          directory: /etc/loki/rules
+      ring:
+        kvstore:
+          store: memberlist
+      rule_path: /tmp/loki/scratch
+      alertmanager_url: https://alertmanager.xx
+      external_url: https://alertmanager.xx
 
   # -- Check https://grafana.com/docs/loki/latest/configuration/#schema_config for more info on how to configure schemas
   schemaConfig:

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -82,7 +82,7 @@ loki:
   # -- Config file contents for Loki
   # @default -- See values.yaml
   config: |
-    auth_enabled: false
+    auth_enabled: true
 
     server:
       {{- toYaml .Values.loki.server | nindent 6 }}

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -2,6 +2,7 @@
 {{- $l:= $v.apps.loki }}
 {{- $obj := $v.obj.provider }}
 {{- $bu := $v.obj.buckets }}
+{{- $useObjectStorage := eq $obj.type "minioLocal" "linode" }}
 
 nameOverride: loki
 
@@ -33,7 +34,7 @@ loki:
       index:
         prefix: loki_index_
         period: 24h
-  {{- if eq $obj.type "minioLocal" "linode" }}
+  {{- if $useObjectStorage }}
   storageConfig:
     boltdb_shipper:
       active_index_directory: /var/loki/index
@@ -57,6 +58,13 @@ loki:
         max_period: 5s
       {{- end }} 
   {{- end }}
+
+  structuredConfig:
+    auth_enabled: true
+    {{- if $useObjectStorage }}
+    compactor:
+      shared_store: s3
+    {{- end }}
 
 ingester:
   resources: {{- $l.resources.ingester | toYaml | nindent 4 }}

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -23,6 +23,7 @@ serviceMonitor:
 loki:
   podAnnotations:
     sidecar.istio.io/inject: "false"
+  auth_enabled: true
   schemaConfig:
     configs:
     - from: 2020-09-07


### PR DESCRIPTION
This PR fixes the broken Loki multi-tenancy. The problem is the setup of the Loki Distributed Helm Chart. Most of the Loki configuration options are combined in just one value `{{ .Values.loki.config }}`. The `auth-enabled` in one of them. In the `loki.config` other Chart values can be used. But not all Loki configuration options are supported in the values.yaml. Using values within values in the values.yaml makes it very difficult to modify values using a .gotmpl.
If any of you has an idea to go around this issue (other than trying to change this in the upstream Grafana helm-charts project), please let me know.
Another option would be (as previously done) provide the full configuration values in the loki.gotmpl. But if we want users to modify config, this would not be the preferred way. 