### PR TITLE
fix: gitea oauth configuration

### DIFF
--- a/charts/otomi-console/values.yaml
+++ b/charts/otomi-console/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   registry: docker.io
-  repository: otomi/console
+  repository: linode/apl-console
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -120,16 +120,6 @@ gitea:
       enabled: true
       additionalLabels:
         prometheus: system
-  oauth:
-    - name: {{ $k.idp.alias }}
-      provider: openidConnect
-      key: {{ $k.idp.clientID  }}
-      secret: {{ $k.idp.clientSecret }}
-      autoDiscoverUrl: {{ $v._derived.oidcWellKnownUrl }}
-      # autoDiscoverUrlBackchannel: {{ $v._derived.oidcWellKnownUrlBackchannel }}
-      autoDiscoverUrlBackchannel: {{ $v._derived.oidcWellKnownUrl }}
-      adminGroup: team-admin
-      groupClaimName: groups
 
 init:
   resources:

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -90,6 +90,8 @@ gitea:
       ENABLE_AUTO_REGISTRATION: true
       ACCOUNT_LINKING: auto
       USERNAME: email
+    oauth2:
+      ENABLED: true
     repository:
       DEFAULT_BRANCH: main
     service:

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -90,8 +90,6 @@ gitea:
       ENABLE_AUTO_REGISTRATION: true
       ACCOUNT_LINKING: auto
       USERNAME: email
-    oauth2:
-      ENABLED: true
     repository:
       DEFAULT_BRANCH: main
     service:

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: main
 console: main
-tasks: 3.0.0
+tasks: fc-fix-gitea-operator
 tools: 1.6.4

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: main
-console: main
+console: fc-feat-linode-dockerhub
 tasks: 3.0.0
 tools: 1.6.4


### PR DESCRIPTION
### Description:
This PR removes Gitea oauth configuration from the `gitea.gotmpl` file. Gitea oauth configuration will be done by apl-gitea-operator.
Is paired with: https://github.com/linode/apl-tasks/pull/108

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
