### PR TITLE
feat: apl-console linode dockerhub

### DIFF
--- a/charts/otomi-console/values.yaml
+++ b/charts/otomi-console/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   registry: docker.io
-  repository: otomi/console
+  repository: linode/apl-console
   tag: latest
   pullPolicy: IfNotPresent
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       GCLOUD_SERVICE_KEY: ${GCLOUD_SERVICE_KEY}
 
   web:
-    image: otomi/console:${WEB_TAG:-latest}
+    image: linode/apl-console:${WEB_TAG:-latest}
     container_name: web
     expose:
       - 80

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -171,7 +171,7 @@ environments:
                         container.image.repository in (
                           docker.io/otomi/tasks,
                           docker.io/otomi/api,
-                          docker.io/otomi/console,
+                          docker.io/linode/apl-console,
                           docker.io/gitea/gitea,
                           docker.io/grafana/grafana
                         ) or (k8s.ns.name = "ingress")
@@ -180,7 +180,7 @@ environments:
                   - macro: excessively_capable_container
                     condition: (
                         container.image.repository in (
-                          docker.io/otomi/console,
+                          docker.io/linode/apl-console,
                           docker.io/otomi/api
                         ) or (k8s.ns.name = "keycloak")
                       )

--- a/helmfile.d/snippets/job.gotmpl
+++ b/helmfile.d/snippets/job.gotmpl
@@ -5,9 +5,10 @@
 {{- $skipScript := . | get "skipScript" false }}
 {{- $task := . | get "task" nil }}
 {{- $type := . | get "type" "job" }}
+{{- $repositoryPrefix := default "otomi" (. | get "repositoryPrefix") }}
 image:
   registry: docker.io
-  repository: otomi/{{ .item }}
+  repository: {{ $repositoryPrefix }}/{{ .item }}
   tag: {{ printf "%s%s" ($isSemver | ternary "v" "") $version }}
   pullPolicy: {{ $isSemver | ternary "IfNotPresent" "Always" }}
 {{ if $v._derived.untrustedCA }}

--- a/helmfile.d/snippets/job.gotmpl
+++ b/helmfile.d/snippets/job.gotmpl
@@ -5,10 +5,10 @@
 {{- $skipScript := . | get "skipScript" false }}
 {{- $task := . | get "task" nil }}
 {{- $type := . | get "type" "job" }}
-{{- $repositoryPrefix := default "otomi" (. | get "repositoryPrefix") }}
+{{- $repositoryPrefix := default "otomi/" (index . "repositoryPrefix" | default "") }}
 image:
   registry: docker.io
-  repository: {{ $repositoryPrefix }}/{{ .item }}
+  repository: {{ $repositoryPrefix }}{{ .item }}
   tag: {{ printf "%s%s" ($isSemver | ternary "v" "") $version }}
   pullPolicy: {{ $isSemver | ternary "IfNotPresent" "Always" }}
 {{ if $v._derived.untrustedCA }}

--- a/values/keycloak-operator/keycloak-operator-cr.gotmpl
+++ b/values/keycloak-operator/keycloak-operator-cr.gotmpl
@@ -50,7 +50,7 @@ spec:
           emptyDir: {}
         initContainers:
         - name: init-container-theme-copy # Otomi branding init container
-          image: docker.io/otomi/console:{{ $v.versions.console }}
+          image: docker.io/linode/apl-console:{{ $v.versions.console }}
           resources: {{ $k.resources.keycloak | toYaml  | nindent 12 }}
           command: 
           - sh 

--- a/values/otomi-console/otomi-console.gotmpl
+++ b/values/otomi-console/otomi-console.gotmpl
@@ -15,7 +15,7 @@ resources:
     memory: 128Mi
   {{- end }}
 
-{{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "item" "console" "v" $v "skipScript" true) }}
+{{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "repositoryPrefix" "linode" "item" "apl-console" "v" $v "skipScript" true) }}
 
 env:
   API_BASE_URL: /api

--- a/values/otomi-console/otomi-console.gotmpl
+++ b/values/otomi-console/otomi-console.gotmpl
@@ -15,7 +15,7 @@ resources:
     memory: 128Mi
   {{- end }}
 
-{{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "repositoryPrefix" "linode" "item" "apl-console" "v" $v "skipScript" true) }}
+{{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "repositoryPrefix" "linode/apl-" "item" "console" "v" $v "skipScript" true ) }}
 
 env:
   API_BASE_URL: /api

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: main
-console: main
+console: fc-feat-linode-dockerhub
 tasks: 3.0.0
 tools: 1.6.4

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: main
-console: fc-feat-linode-dockerhub
+console: main
 tasks: 3.0.0
 tools: 1.6.4


### PR DESCRIPTION
### Implements:
https://jira.linode.com/browse/APL-135

### Description:
This PR updates otomi-console files to pull the `apl-console` image from the linode docker hub.
https://hub.docker.com/repository/docker/linode/apl-console/general

Is paired with: https://github.com/linode/apl-console/pull/423

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
