### PR TITLE
feat: linode dockerhub apl-tty

### DIFF
--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -6,8 +6,10 @@ on:
       - 'main'
 
 env:
-  NAMESPACE: otomi
-  REPO: tty
+  NAMESPACE: linode
+  REPO: apl-tty
+  DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_LINODEBOT_TOKEN }}
+  DOCKER_USERNAME: ${{ vars.DOCKERHUB_LINODEBOT_USERNAME }}
 
 jobs:
   build-and-version:
@@ -68,14 +70,14 @@ jobs:
         if: ${{ env.NEW_VERSION != null }}
         run: |
           pip3 install docker-squash
-          docker-squash otomi/tty -t ${{ env.NAMESPACE }}/${{ env.REPO }}:${{ env.NEW_VERSION }}
+          docker-squash ${{ env.NAMESPACE }}/${{ env.REPO }} -t ${{ env.NAMESPACE }}/${{ env.REPO }}:${{ env.NEW_VERSION }}
 
       - name: Login to GitHub Container Registry
         if: ${{ env.NEW_VERSION != null }}
         uses: docker/login-action@v3
         with:
-          username: 'otomi'
-          password: '${{ secrets.DOCKERHUB_OTOMI_TOKEN }}'
+          username: '$DOCKER_USERNAME'
+          password: '$DOCKER_PASSWORD'
 
       - name: Push Docker image
         if: ${{ env.NEW_VERSION != null }}

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -31,7 +31,8 @@ jobs:
           set -e
 
           # # Set the first image version to '0.1.0' if the repo does not exists.
-          if ! curl -s -L --fail "https://hub.docker.com/v2/repositories/${{ env.NAMESPACE }}/${{ env.REPO }}"; then echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0; fi
+          # if ! curl -s -L --fail "https://hub.docker.com/v2/repositories/${{ env.NAMESPACE }}/${{ env.REPO }}"; then echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0; fi
+          echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0
 
           # Get data for latest 10 versions of the image and filter the ones matching our semver pattern. Set the OLD_VERSION environment variable to the latest version.
           # The grep command matches the strings following this pattern: starts with an up to 2 digits number, a dot, an up to 3 digit number, a dot, ends with an up to 4 digits number

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -30,8 +30,8 @@ jobs:
 
           set -e
 
-          # # Set the first image version to '0.1.0' if the repo does  not exists.
-          # if ! curl -s -L --fail "https://hub.docker.com/v2/repositories/${{ env.NAMESPACE }}/${{ env.REPO }}"; then echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0; fi
+          # # Set the first image version to '0.1.0' if the repo does not exists.
+          if ! curl -s -L --fail "https://hub.docker.com/v2/repositories/${{ env.NAMESPACE }}/${{ env.REPO }}"; then echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0; fi
 
           # Get data for latest 10 versions of the image and filter the ones matching our semver pattern. Set the OLD_VERSION environment variable to the latest version.
           # The grep command matches the strings following this pattern: starts with an up to 2 digits number, a dot, an up to 3 digit number, a dot, ends with an up to 4 digits number

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -8,8 +8,6 @@ on:
 env:
   NAMESPACE: linode
   REPO: apl-tty
-  DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_LINODEBOT_TOKEN }}
-  DOCKER_USERNAME: ${{ vars.DOCKERHUB_LINODEBOT_USERNAME }}
 
 jobs:
   build-and-version:
@@ -32,7 +30,7 @@ jobs:
 
           # # Set the first image version to '0.1.0' if the repo does not exists.
           # if ! curl -s -L --fail "https://hub.docker.com/v2/repositories/${{ env.NAMESPACE }}/${{ env.REPO }}"; then echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0; fi
-          echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0
+          echo "NEW_VERSION=1.1.3" >> $GITHUB_ENV && exit 0
 
           # Get data for latest 10 versions of the image and filter the ones matching our semver pattern. Set the OLD_VERSION environment variable to the latest version.
           # The grep command matches the strings following this pattern: starts with an up to 2 digits number, a dot, an up to 3 digit number, a dot, ends with an up to 4 digits number
@@ -77,8 +75,8 @@ jobs:
         if: ${{ env.NEW_VERSION != null }}
         uses: docker/login-action@v3
         with:
-          username: '$DOCKER_USERNAME'
-          password: '$DOCKER_PASSWORD'
+          username: ${{ vars.DOCKERHUB_LINODEBOT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LINODEBOT_TOKEN }}
 
       - name: Push Docker image
         if: ${{ env.NEW_VERSION != null }}

--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -3,7 +3,7 @@ name: CloudTTY Build and Versioning
 on:
   push:
     branches:
-      - 'main'
+      - 'linode-dockerhub-apl-tty'
 
 env:
   NAMESPACE: linode

--- a/tools/Dockerfile-tty
+++ b/tools/Dockerfile-tty
@@ -1,8 +1,8 @@
 # syntax=docker/dockerfile:1.6
 # The above is needed for the "--checksum" aurgument to work in the ADD instruction
 
-# Using ubuntu:latest base image
-FROM ubuntu:latest
+# Using ubuntu:noble base image
+FROM ubuntu:jammy
 
 # Installing curl, vim, wget, tmux ttyd and bash-completion
 RUN apt update && apt upgrade -y && apt install -y ttyd jq curl vim wget less tmux bash-completion 


### PR DESCRIPTION
### Implements:
https://jira.linode.com/browse/APL-135

### Description:
This PR updates otomi-tty files to push/pull the `apl-tty` image from the linode docker hub.
https://hub.docker.com/repository/docker/linode/apl-tty/general

Is paired with: https://github.com/linode/apl-api/pull/542

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
