### PR TITLE
fix: loki storage config without OBJ

### DIFF
--- a/tests/fixtures/env/secrets.settings.yaml
+++ b/tests/fixtures/env/secrets.settings.yaml
@@ -26,12 +26,8 @@ smtp:
     auth_password: somesecretvalue
 obj:
     provider:
-        # s3:
+        # linode:
         #     secretAccessKey: somesecretvalue
-        linode:
-            secretAccessKey: somesecretvalue
-        # azureBlob:
-        #     aadClientSecret: somesecretvalue
 platformBackups:
     persistentVolumes:
         linodeApiToken: justanapitokenhere

--- a/tests/fixtures/env/secrets.settings.yaml
+++ b/tests/fixtures/env/secrets.settings.yaml
@@ -24,10 +24,10 @@ otomi:
         password: blablabla
 smtp:
     auth_password: somesecretvalue
-# obj:
-#     provider:
-# linode:
-#     secretAccessKey: somesecretvalue
+obj:
+    provider:
+        linode:
+            secretAccessKey: somesecretvalue
 platformBackups:
     persistentVolumes:
         linodeApiToken: justanapitokenhere

--- a/tests/fixtures/env/secrets.settings.yaml
+++ b/tests/fixtures/env/secrets.settings.yaml
@@ -24,10 +24,10 @@ otomi:
         password: blablabla
 smtp:
     auth_password: somesecretvalue
-obj:
-    provider:
-        # linode:
-        #     secretAccessKey: somesecretvalue
+# obj:
+#     provider:
+# linode:
+#     secretAccessKey: somesecretvalue
 platformBackups:
     persistentVolumes:
         linodeApiToken: justanapitokenhere

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -59,10 +59,10 @@ obj:
         tempo: my-clusterid-tempo
         velero: my-clusterid-velero
     provider:
-        linode:
-            accessKeyId: someaccessKeyId
-            region: nl-ams-1
-        type: linode
+        # linode:
+        #     accessKeyId: someaccessKeyId
+        #     region: nl-ams-1
+        type: disabled
 oidc:
     adminGroupID: someAdminGroupID
     clientID: someClientID

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -59,10 +59,10 @@ obj:
         tempo: my-clusterid-tempo
         velero: my-clusterid-velero
     provider:
-        # linode:
-        #     accessKeyId: someaccessKeyId
-        #     region: nl-ams-1
-        type: disabled
+        linode:
+            accessKeyId: someaccessKeyId
+            region: nl-ams-1
+        type: linode
 oidc:
     adminGroupID: someAdminGroupID
     clientID: someClientID

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -29,18 +29,26 @@ loki:
     configs:
     - from: 2020-09-07
       store: boltdb-shipper
+      {{- if $useObjectStorage }}
       object_store: s3
+      {{- else }}
+      object_store: filesystem
+      {{- end }}
       schema: v11
       index:
         prefix: loki_index_
         period: 24h
-  {{- if $useObjectStorage }}
   storageConfig:
     boltdb_shipper:
       active_index_directory: /var/loki/index
       cache_location: /var/loki/index_cache
       resync_interval: 5s
+      {{- if $useObjectStorage }}
       shared_store: s3
+      {{- else }}
+      shared_store: filesystem
+      {{- end }}
+    {{- if $useObjectStorage }}
     aws:
       {{- if eq $obj.type "minioLocal" }}
       s3: http://otomi-admin:{{ $v.otomi.adminPassword }}@minio.minio.svc.cluster.local.:9000/{{ $bu.loki }}
@@ -56,8 +64,11 @@ loki:
       backoff_config:
         min_period: 2s
         max_period: 5s
-      {{- end }} 
-  {{- end }}
+      {{- end }}
+    {{- else }}
+    filesystem:
+      directory: "/var/loki/chunks"
+    {{- end }}
 
   structuredConfig:
     auth_enabled: true


### PR DESCRIPTION
When OBJ is not configured (or set to disabled), the Loki storageConfig is now configured to use filesystem. This allows to use Loki without OBJ.
