### PR TITLE
fix: argocd hpa defaults

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -18,14 +18,14 @@ environments:
                 enabled: true
                 minReplicas: 1
                 maxReplicas: 5
-                targetCPUUtilizationPercentage: 70
-                targetMemoryUtilizationPercentage: 70
+                targetCPUUtilizationPercentage: 80
+                targetMemoryUtilizationPercentage: 80
               server:
                 enabled: true
                 minReplicas: 1
                 maxReplicas: 5
-                targetCPUUtilizationPercentage: 70
-                targetMemoryUtilizationPercentage: 70
+                targetCPUUtilizationPercentage: 80
+                targetMemoryUtilizationPercentage: 80
             resources:
               controller:
                 requests:
@@ -36,8 +36,8 @@ environments:
                   memory: 2Gi
               server:
                 requests:
-                  cpu: 50m
-                  memory: 256M
+                  cpu: 100m
+                  memory: 512M
                 limits:
                   cpu: "1"
                   memory: 1Gi

--- a/values/argocd/argocd.gotmpl
+++ b/values/argocd/argocd.gotmpl
@@ -35,6 +35,7 @@ repoServer:
     maxReplicas: {{ $a.autoscaling.repoServer.maxReplicas }}
     minReplicas: {{ $a.autoscaling.repoServer.minReplicas }}
     targetMemoryUtilizationPercentage: {{ $a.autoscaling.repoServer.targetMemoryUtilizationPercentage }}
+    targetCPUUtilizationPercentage: {{ $a.autoscaling.repoServer.targetCPUUtilizationPercentage }}
   resources: {{- $a.resources.repo | toYaml | nindent 4 }}
 
 server:
@@ -43,6 +44,7 @@ server:
     maxReplicas: {{ $a.autoscaling.server.maxReplicas }}
     minReplicas: {{ $a.autoscaling.server.minReplicas }}
     targetMemoryUtilizationPercentage: {{ $a.autoscaling.server.targetMemoryUtilizationPercentage }}
+    targetCPUUtilizationPercentage: {{ $a.autoscaling.server.targetCPUUtilizationPercentage }}
   resources: {{- $a.resources.server | toYaml | nindent 4 }}
 
 configs:


### PR DESCRIPTION
This PR fixes: override the default`targetMemoryUtilizationPercentage` to 70 for the server and repo-server HPA
