### PR TITLE
feat: linode dockerhub apl-core and apl-tools

### DIFF
--- a/.github/ISSUE_TEMPLATE/k8s_support.md
+++ b/.github/ISSUE_TEMPLATE/k8s_support.md
@@ -25,8 +25,8 @@ Get familiar with the `schemas/Readme.md` file
 
 - [ ] Kubectl [version skew](https://kubernetes.io/releases/version-skew-policy/#kubectl) from is compatible with all three supported k8s versions
 - [ ] Helm [version skew](https://helm.sh/docs/topics/version_skew/#supported-version-skew) from is compatible with all three supported k8s versions
-- [ ] A new otomi/tools version is published
-- [ ] The otomi/tools version is used by the otomi/core image
+- [ ] A new linode/apl-tools version is published
+- [ ] The linode/apl-tools version is used by the otomi/core image
 
 **.github/workflows**
 

--- a/.github/ISSUE_TEMPLATE/k8s_support.md
+++ b/.github/ISSUE_TEMPLATE/k8s_support.md
@@ -26,7 +26,7 @@ Get familiar with the `schemas/Readme.md` file
 - [ ] Kubectl [version skew](https://kubernetes.io/releases/version-skew-policy/#kubectl) from is compatible with all three supported k8s versions
 - [ ] Helm [version skew](https://helm.sh/docs/topics/version_skew/#supported-version-skew) from is compatible with all three supported k8s versions
 - [ ] A new linode/apl-tools version is published
-- [ ] The linode/apl-tools version is used by the otomi/core image
+- [ ] The linode/apl-tools version is used by the linode/apl-core image
 
 **.github/workflows**
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -123,7 +123,7 @@ on:
 env:
   CACHE_REGISTRY: ghcr.io
   CACHE_REPO: linode/apl-core
-  REPO: otomi/core
+  REPO: linode/apl-core
   GIT_USER: svcAPLBot
   SCALEWAY_NODE_TYPE: PRO2-M
   SCALEWAY_NODE_POOL_MIN_SIZE: 3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
     if: always() && contains(needs.release.result, 'success') && !github.event.act
     runs-on: ubuntu-latest
     container:
-      image: otomi/tools:v1.4.20
+      image: linode/apl-tools:v2.4.0
       options: --user 0
     steps:
       - name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,9 @@ on:
 env:
   CACHE_REGISTRY: ghcr.io
   CACHE_REPO: linode/apl-core
-  REPO: otomi/core
+  REPO: linode/apl-core
+  DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_LINODEBOT_TOKEN }}
+  DOCKER_USERNAME: ${{ vars.DOCKERHUB_LINODEBOT_USERNAME }}
 
 jobs:
   build-test-cache:
@@ -60,7 +62,7 @@ jobs:
           image="$CACHE_REGISTRY/$CACHE_REPO:$TAG"
           docker pull $image
           docker tag $image $REPO:$TAG
-          docker login -u otomi -p ${{ secrets.DOCKERHUB_OTOMI_TOKEN }}
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
           docker push $REPO:$TAG
       - name: Show me the logic
         run: |
@@ -83,7 +85,7 @@ jobs:
         id: git_tag
         run: |
           TAG=${GITHUB_REF##*/}
-          docker login -u otomi -p ${{ secrets.DOCKERHUB_OTOMI_TOKEN }}
+          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
           docker pull $REPO:$TAG
           docker tag $REPO:$TAG $REPO:latest
           docker push $REPO:latest

--- a/.github/workflows/otomi-tools-build-push.yaml
+++ b/.github/workflows/otomi-tools-build-push.yaml
@@ -44,6 +44,7 @@ jobs:
 
           # # Set the first image version to '0.1.0' if the repo does  not exists.
           # if ! curl -s -L --fail "https://hub.docker.com/v2/repositories/${{ env.NAMESPACE }}/${{ env.REPO }}"; then echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0; fi
+          "NEW_VERSION=2.4.0" >> $GITHUB_ENV && exit 0;
 
           # Get data for latest 10 versions of the image and filter the ones matching our semver pattern. Set the OLD_VERSION environment variable to the latest version.
           # The grep command matches the strings following this pattern: starts with an up to 2 digits number, a dot, an up to 3 digit number, a dot, ends with an up to 4 digits number

--- a/.github/workflows/otomi-tools-build-push.yaml
+++ b/.github/workflows/otomi-tools-build-push.yaml
@@ -1,4 +1,4 @@
-name: Otomi Tools Build and Versioning
+name: APL Tools Build and Versioning
 
 on:
   workflow_dispatch:
@@ -44,7 +44,7 @@ jobs:
 
           # # Set the first image version to '0.1.0' if the repo does  not exists.
           # if ! curl -s -L --fail "https://hub.docker.com/v2/repositories/${{ env.NAMESPACE }}/${{ env.REPO }}"; then echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0; fi
-          "NEW_VERSION=2.4.0" >> $GITHUB_ENV && exit 0;
+          echo "NEW_VERSION=2.4.0" >> $GITHUB_ENV && exit 0
 
           # Get data for latest 10 versions of the image and filter the ones matching our semver pattern. Set the OLD_VERSION environment variable to the latest version.
           # The grep command matches the strings following this pattern: starts with an up to 2 digits number, a dot, an up to 3 digit number, a dot, ends with an up to 4 digits number

--- a/.github/workflows/otomi-tools-build-push.yaml
+++ b/.github/workflows/otomi-tools-build-push.yaml
@@ -10,7 +10,7 @@ on:
         type: string
   push:
     branches:
-      - 'linode-dockerhub-apl-tools'
+      - 'main'
 
 env:
   NAMESPACE: linode
@@ -44,7 +44,6 @@ jobs:
 
           # # Set the first image version to '0.1.0' if the repo does  not exists.
           # if ! curl -s -L --fail "https://hub.docker.com/v2/repositories/${{ env.NAMESPACE }}/${{ env.REPO }}"; then echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0; fi
-          echo "NEW_VERSION=v2.4.0" >> $GITHUB_ENV && exit 0
 
           # Get data for latest 10 versions of the image and filter the ones matching our semver pattern. Set the OLD_VERSION environment variable to the latest version.
           # The grep command matches the strings following this pattern: starts with an up to 2 digits number, a dot, an up to 3 digit number, a dot, ends with an up to 4 digits number

--- a/.github/workflows/otomi-tools-build-push.yaml
+++ b/.github/workflows/otomi-tools-build-push.yaml
@@ -13,8 +13,8 @@ on:
       - 'main'
 
 env:
-  NAMESPACE: otomi
-  REPO: tools
+  NAMESPACE: linode
+  REPO: apl-tools
 
 jobs:
   build-and-version:
@@ -76,8 +76,8 @@ jobs:
         if: ${{ env.NEW_VERSION != null }}
         uses: docker/login-action@v3
         with:
-          username: 'otomi'
-          password: '${{ secrets.DOCKERHUB_OTOMI_TOKEN }}'
+          username: ${{ vars.DOCKERHUB_LINODEBOT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LINODEBOT_TOKEN }}
       - name: image build and push tag for branch
         if: ${{ env.NEW_VERSION != null }}
         uses: docker/build-push-action@v5

--- a/.github/workflows/otomi-tools-build-push.yaml
+++ b/.github/workflows/otomi-tools-build-push.yaml
@@ -10,7 +10,7 @@ on:
         type: string
   push:
     branches:
-      - 'main'
+      - 'linode-dockerhub-apl-tools'
 
 env:
   NAMESPACE: linode

--- a/.github/workflows/otomi-tools-build-push.yaml
+++ b/.github/workflows/otomi-tools-build-push.yaml
@@ -44,7 +44,7 @@ jobs:
 
           # # Set the first image version to '0.1.0' if the repo does  not exists.
           # if ! curl -s -L --fail "https://hub.docker.com/v2/repositories/${{ env.NAMESPACE }}/${{ env.REPO }}"; then echo "NEW_VERSION=0.1.0" >> $GITHUB_ENV && exit 0; fi
-          echo "NEW_VERSION=2.4.0" >> $GITHUB_ENV && exit 0
+          echo "NEW_VERSION=v2.4.0" >> $GITHUB_ENV && exit 0
 
           # Get data for latest 10 versions of the image and filter the ones matching our semver pattern. Set the OLD_VERSION environment variable to the latest version.
           # The grep command matches the strings following this pattern: starts with an up to 2 digits number, a dot, an up to 3 digit number, a dot, ends with an up to 4 digits number

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM otomi/tools:v2.3.0 as ci
+FROM linode/apl-tools:v2.4.0 as ci
 
 ENV APP_HOME=/home/app/stack
 
@@ -27,7 +27,7 @@ FROM ci as clean
 RUN npm prune --production
 
 #-----------------------------
-FROM otomi/tools:v2.3.0 as prod
+FROM linode/apl-tools:v2.4.0 as prod
 
 ENV APP_HOME=/home/app/stack
 ENV ENV_DIR=/home/app/stack/env

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -18,7 +18,7 @@ LOG_LEVEL='--log-level warn'
 
 # Common vars
 readonly otomi_settings="$ENV_DIR/env/settings.yaml"
-readonly otomi_tools_image="otomi/core:latest"
+readonly otomi_tools_image="linode/apl-core:latest"
 [ $(uname -s) == 'Linux' ] && readonly LINUX_WORKAROUND='--user=root:root'
 
 # Mutliple files vars
@@ -45,7 +45,7 @@ function err() {
 # skip parsing args for some commands
 caller=${1#./}
 if [ "$caller" == 'bin/otomi' ] || [[ ! "x bash bats" == *"$1"* ]]; then
-  ! getopt --test >/dev/null
+  getopt --test >/dev/null && exit 1
   if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
     err '`getopt --test` failed in this environment.'
     exit 1
@@ -53,7 +53,7 @@ if [ "$caller" == 'bin/otomi' ] || [[ ! "x bash bats" == *"$1"* ]]; then
 
   OPTIONS=dtvsp:f:l:
   LONGOPTS=debug,trace,verbose,skip-cleanup,profile:,file:,label:
-  ! PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")
+  PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@") && exit 1
   if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
     exit 1
   fi

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -45,7 +45,7 @@ function err() {
 # skip parsing args for some commands
 caller=${1#./}
 if [ "$caller" == 'bin/otomi' ] || [[ ! "x bash bats" == *"$1"* ]]; then
-  getopt --test >/dev/null && exit 1
+  ! getopt --test >/dev/null
   if [[ ${PIPESTATUS[0]} -ne 4 ]]; then
     err '`getopt --test` failed in this environment.'
     exit 1
@@ -53,7 +53,7 @@ if [ "$caller" == 'bin/otomi' ] || [[ ! "x bash bats" == *"$1"* ]]; then
 
   OPTIONS=dtvsp:f:l:
   LONGOPTS=debug,trace,verbose,skip-cleanup,profile:,file:,label:
-  PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@") && exit 1
+  ! PARSED=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")
   if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
     exit 1
   fi

--- a/binzx/README.md
+++ b/binzx/README.md
@@ -3,7 +3,7 @@
 ```sh
 # In the apl-core directory
 export DOCKER_TAG=binzx
-docker build --target prod -t otomi/core:binzx .
+docker build --target prod -t linode/apl-core:binzx .
 ./binzx/otomi <commands here>
 ```
 

--- a/binzx/otomi
+++ b/binzx/otomi
@@ -90,7 +90,7 @@ else
 fi
 otomi_branch_or_tag=${OTOMI_TAG:-$otomi_version}
 otomi_version_used=${OTOMI_TAG:-$otomi_version}
-readonly otomi_tools_image="otomi/core:${otomi_version_used}"
+readonly otomi_tools_image="linode/apl-core:${otomi_version_used}"
 
 script_full_path="$base_dir/${BASH_SOURCE[0]##*/}"
 if [[ ${BASH_SOURCE[0]} == '/'* ]]; then

--- a/binzx/otomi
+++ b/binzx/otomi
@@ -8,7 +8,7 @@
 ## - do not depend on any external files.
 ## - do not use any non standard tooling.
 ## - only Docker is needed to run apl-core image
-## If you need to use any extra binaries then most probably you want to add them to the otomi/tools image.
+## If you need to use any extra binaries then most probably you want to add them to the linode/apl-tools image.
 ##
 #####################################################################################
 # shellcheck disable=SC2128

--- a/chart/apl/templates/job.yaml
+++ b/chart/apl/templates/job.yaml
@@ -1,5 +1,5 @@
 {{- $kms := .Values.kms | default dict }}
-{{- $imageName := .Values.imageName | default "otomi/core" }}
+{{- $imageName := .Values.imageName | default "linode/apl-core" }}
 {{- $version := .Values.otomi.version | default .Chart.AppVersion }}
 apiVersion: batch/v1
 kind: Job

--- a/chart/apl/templates/post-job.yaml
+++ b/chart/apl/templates/post-job.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: destroy
-          image: otomi/core:{{ $version }}
+          image: linode/apl-core:{{ $version }}
           imagePullPolicy: {{ ternary "IfNotPresent" "Always" (regexMatch "^v\\d" $version) }} 
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/otomi-api/values.yaml
+++ b/charts/otomi-api/values.yaml
@@ -102,7 +102,7 @@ core: {}
 tools:
   image:
     registry: docker.io
-    repository: otomi/core
+    repository: linode/apl-core
     tag: latest
     pullPolicy: IfNotPresent
 

--- a/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
@@ -32,7 +32,7 @@ spec:
   stepTemplate:
     computeResources: {{- toYaml .Values.tektonTask.resources | nindent 6 }}
     workingDir: $(workspaces.source.path)
-    image: otomi/core:{{ .Values.otomiVersion }}
+    image: linode/apl-core:{{ .Values.otomiVersion }}
   steps:
     - name: git-clone
       computeResources: {}

--- a/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
@@ -23,7 +23,7 @@ spec:
   stepTemplate:
     computeResources: {{- toYaml .Values.tektonTask.resources | nindent 6 }}
     imagePullPolicy: Always
-    image: otomi/core:$(params["OTOMI_VERSION"])
+    image: linode/apl-core:$(params["OTOMI_VERSION"])
     workingDir: /home/app/stack
 {{- if hasKey $kms "sops" }}
     envFrom:

--- a/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
@@ -23,7 +23,7 @@ spec:
   stepTemplate:
     computeResources: {{- toYaml .Values.tektonTask.resources | nindent 6 }}
     imagePullPolicy: Always
-    image: otomi/core:$(params["OTOMI_VERSION"])
+    image: linode/apl-core:$(params["OTOMI_VERSION"])
     workingDir: /home/app/stack
 {{- if hasKey $kms "sops" }}
     envFrom:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   tools:
     container_name: tools
-    image: otomi/core:${TOOLS_TAG:-latest}
+    image: linode/apl-core:${TOOLS_TAG:-latest}
     user: ${USER_ID}:${GROUP_ID}
     command: npm run compile && node --no-warnings ./dist/src/otomi.js -- server
     depends_on:

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -122,7 +122,7 @@ environments:
                           quay.io/prometheus-operator/prometheus-operator,
                           quay.io/prometheus/prometheus,
                           quay.io/kiwigrid/k8s-sidecar,
-                          docker.io/otomi/core,
+                          docker.io/linode/apl-core,
                           docker.io/linode/apl-tasks,
                           docker.io/linode/apl-api,
                           docker.io/drone/drone-runner-kube,
@@ -163,7 +163,7 @@ environments:
                     condition: (
                         container.image.repository in (
                           docker.io/linode/apl-tasks,
-                          ocker.io/otomi/core
+                          docker.io/linode/apl-core
                         ) or (k8s.ns.name = "drone-pipelines")
                       )
                   - macro: user_known_non_sudo_setuid_conditions

--- a/helmfile.d/snippets/job.gotmpl
+++ b/helmfile.d/snippets/job.gotmpl
@@ -5,10 +5,9 @@
 {{- $skipScript := . | get "skipScript" false }}
 {{- $task := . | get "task" nil }}
 {{- $type := . | get "type" "job" }}
-{{- $repositoryPrefix := default "otomi/" (index . "repositoryPrefix" | default "") }}
 image:
   registry: docker.io
-  repository: {{ $repositoryPrefix }}{{ .item }}
+  repository: linode/apl-{{ .item }}
   tag: {{ printf "%s%s" ($isSemver | ternary "v" "") $version }}
   pullPolicy: {{ $isSemver | ternary "IfNotPresent" "Always" }}
 {{ if $v._derived.untrustedCA }}

--- a/src/cmd/bootstrap.ts
+++ b/src/cmd/bootstrap.ts
@@ -359,7 +359,7 @@ export const bootstrap = async (
   const { ENV_DIR } = env
   const hasOtomi = await deps.pathExists(`${ENV_DIR}/bin/otomi`)
 
-  const otomiImage = `otomi/core:${tag}`
+  const otomiImage = `linode/apl-core:${tag}`
   d.log(`Installing artifacts from ${otomiImage}`)
   await deps.copyBasicFiles()
   await deps.migrate()

--- a/tools/Readme.md
+++ b/tools/Readme.md
@@ -1,11 +1,11 @@
-# Building otomi/tools container image
+# Building linode/apl-tools container image
 
 ```
-docker build . -f Dockerfile -t otomi/tools:<TAG>
+docker build . -f Dockerfile -t linode/apl-tools:<TAG>
 ```
 
-# Building otomi/tools-db container image
+# Building linode/apl-tools-db container image
 
 ```
-docker build . -f Dockerfile-db -t otomi/tools-db:<TAG>
+docker build . -f Dockerfile-db -t linode/apl-tools-db:<TAG>
 ```

--- a/values/otomi-api/otomi-api.gotmpl
+++ b/values/otomi-api/otomi-api.gotmpl
@@ -56,7 +56,7 @@ core:
   {{ readFile "../../apps.yaml" | nindent 2}}
 
 tools:
-  {{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "item" "core" "v" $v "skipScript" true) | nindent 2 }}
+  {{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "repositoryPrefix" "linode/apl-" "item" "core" "v" $v "skipScript" true) | nindent 2 }}
   resources:
   {{- with $o | get "resources.tools" nil }}
     {{- toYaml . | nindent 4 }}

--- a/values/otomi-api/otomi-api.gotmpl
+++ b/values/otomi-api/otomi-api.gotmpl
@@ -24,7 +24,7 @@ resources:
     memory: 256Mi
 {{- end }}
 
-{{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "repositoryPrefix" "linode/apl-" "item" "api" "v" $v "skipScript" true) }}
+{{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "item" "api" "v" $v "skipScript" true) }}
 
 secrets:
   GIT_USER: otomi-admin
@@ -56,7 +56,7 @@ core:
   {{ readFile "../../apps.yaml" | nindent 2}}
 
 tools:
-  {{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "repositoryPrefix" "linode/apl-" "item" "core" "v" $v "skipScript" true) | nindent 2 }}
+  {{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "item" "core" "v" $v "skipScript" true) | nindent 2 }}
   resources:
   {{- with $o | get "resources.tools" nil }}
     {{- toYaml . | nindent 4 }}

--- a/values/otomi-console/otomi-console.gotmpl
+++ b/values/otomi-console/otomi-console.gotmpl
@@ -15,7 +15,7 @@ resources:
     memory: 128Mi
   {{- end }}
 
-{{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "repositoryPrefix" "linode/apl-" "item" "console" "v" $v "skipScript" true ) }}
+{{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "item" "console" "v" $v "skipScript" true ) }}
 
 env:
   API_BASE_URL: /api

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 api: main
 console: main
 tasks: 3.0.0
-tools: 1.6.4
+tools: 2.4.0


### PR DESCRIPTION
### Implements:
https://jira.linode.com/browse/APL-135

### Description:
This PR updates the `otomi-core` and `otomi-tools` configurations to ensure that the `apl-core` and `apl-tools` images are pulled from and pushed to the linode dockerhub.

Please note that there is no GitHub workflow set up for the `apl-tools-db` image. As a result, the `apl-tools-db` image has been manually pushed to the new registry.

https://hub.docker.com/repository/docker/linode/apl-core/general
https://hub.docker.com/repository/docker/linode/apl-tools/general
https://hub.docker.com/repository/docker/linode/apl-tools-db/general

### Testing:
Please ensure that all the images mentioned in [this ticket](https://jira.linode.com/browse/APL-135) are pulled from the new registry by following the steps below:

- Use the feature branch from this PR to create a new Kubernetes cluster.
- Ensure that the cluster is created successfully without any errors.
- Start a new shell (cloudtty) session from the team view to see the `apl-tty` image in the list (You might need to open in a new tab to ignore the SSL issue)
- Use the following kubectl commands to list all the images used by the running pods and deployments:
**Pods:**
`kubectl get pods --all-namespaces -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | sort | uniq`
**Deployments:**
`kubectl get deployments --all-namespaces -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | sort | uniq`
- Confirm that all `apl` images (formerly `otomi`) are pulled from the new linode dockerhub registry.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
