### PR TITLE
fix: set workflow input to 1.29

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,9 +7,9 @@ on:
         type: string
         default: linode
       kubernetes_versions:
-        description: "Kubernetes versions (JSON formatted list e.g.: ['1.27'])"
+        description: "Kubernetes versions (JSON formatted list e.g.: ['1.28'])"
         type: string
-        default: "['1.28']"
+        default: "['1.29']"
       install_profile:
         description: Otomi installation profile
         default: full


### PR DESCRIPTION
This PR sets the workflow input for k8s version to 1.29.
The previous input was still 1.28 but linode does not support that version anymore when creating new clusters.
Because of this it tried to match 1.28 to one the supported versions, which does not work and results in the workflow failing.

Linode Console
![image](https://github.com/user-attachments/assets/c927acbf-f5e2-4b35-bd0c-4bf987d51f13)

Linode CLI command
![image](https://github.com/user-attachments/assets/166aba79-3e2c-430c-a1fe-4391824a6a95)

Failed Pipeline because the k8s version is empty
![image](https://github.com/user-attachments/assets/d545ed04-8e0d-4c70-9a82-81f3e31b0e65)
