### PR TITLE
fix: clone repo in pipeline

### DIFF
--- a/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
@@ -61,7 +61,7 @@ spec:
         {{- if .Values.cloneUnsecure }}
         git clone -c http.sslVerify=false --depth 2 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url
         {{- else }}
-        git clone --depth 2 https://$GITEA_USERNAME:$GITEA_PASSWORD@$url
+        git clone --depth 2 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url
         {{- end }}
 
         # Checking if the next steps should run or skipped 


### PR DESCRIPTION
Fixes error:

```
gitea-http.gitea.svc.cluster.local:3000/otomi/values.git/
Cloning into 'values'...
warning: templates not found in /usr/share/git-core/templates
fatal: unable to access 'https://gitea-http.gitea.svc.cluster.local:3000/otomi/values.git/': gnutls_handshake() failed: Error in the pull function
```