### PR TITLE
feat: fix argocd out of sync issues

### DIFF
--- a/src/cmd/apply-as-apps.ts
+++ b/src/cmd/apply-as-apps.ts
@@ -43,6 +43,17 @@ const getAppName = (release: HelmRelease): string => {
 }
 
 const getArgocdAppManifest = (release: HelmRelease, values: Record<string, any>, otomiVersion) => {
+  const releases = [
+    'tempo',
+    'thanos',
+    'cert-manager',
+    'cloudnative-pg',
+    'prometheus-operator',
+    'tekton-pipelines',
+    'tekton-triggers',
+  ]
+  const releaseNameMatches = releases.includes(release.name) || /^nginx-.*/.test(release.name)
+
   return {
     apiVersion: 'argoproj.io/v1alpha1',
     kind: 'Application',
@@ -52,7 +63,7 @@ const getArgocdAppManifest = (release: HelmRelease, values: Record<string, any>,
         'otomi.io/app': 'managed',
       },
       namespace: 'argocd',
-      annotations: ['tempo', 'thanos'].includes(release.name)
+      annotations: releaseNameMatches
         ? {
             'argocd.argoproj.io/compare-options': 'ServerSideDiff=true,IncludeMutationWebhook=true',
           }

--- a/src/cmd/apply-as-apps.ts
+++ b/src/cmd/apply-as-apps.ts
@@ -51,6 +51,8 @@ const getArgocdAppManifest = (release: HelmRelease, values: Record<string, any>,
     'prometheus-operator',
     'tekton-pipelines',
     'tekton-triggers',
+    'jaeger-operator',
+    'otel-operator',
   ]
   const releaseNameMatches = releases.includes(release.name) || /^nginx-.*/.test(release.name)
 

--- a/src/cmd/apply-as-apps.ts
+++ b/src/cmd/apply-as-apps.ts
@@ -43,19 +43,6 @@ const getAppName = (release: HelmRelease): string => {
 }
 
 const getArgocdAppManifest = (release: HelmRelease, values: Record<string, any>, otomiVersion) => {
-  const releases = [
-    'tempo',
-    'thanos',
-    'cert-manager',
-    'cloudnative-pg',
-    'prometheus-operator',
-    'tekton-pipelines',
-    'tekton-triggers',
-    'jaeger-operator',
-    'otel-operator',
-  ]
-  const releaseNameMatches = releases.includes(release.name) || /^nginx-.*/.test(release.name)
-
   return {
     apiVersion: 'argoproj.io/v1alpha1',
     kind: 'Application',
@@ -65,11 +52,9 @@ const getArgocdAppManifest = (release: HelmRelease, values: Record<string, any>,
         'otomi.io/app': 'managed',
       },
       namespace: 'argocd',
-      annotations: releaseNameMatches
-        ? {
-            'argocd.argoproj.io/compare-options': 'ServerSideDiff=true,IncludeMutationWebhook=true',
-          }
-        : {},
+      annotations: {
+        'argocd.argoproj.io/compare-options': 'ServerSideDiff=true,IncludeMutationWebhook=true',
+      },
     },
     spec: {
       syncPolicy: {

--- a/values/argocd/argocd.gotmpl
+++ b/values/argocd/argocd.gotmpl
@@ -97,6 +97,9 @@ configs:
     resource.customizations.knownTypeFields.cert-manager.io_Certificate: |
         - field: spec.duration
           type: meta/v1/Duration
+    resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
+        jqPathExpressions:
+          - '.metadata.annotations."argocd.argoproj.io/tracking-id"'
     oidc.config: |
       name: Otomi
       issuer: {{ $v._derived.oidcBaseUrl }}

--- a/values/argocd/argocd.gotmpl
+++ b/values/argocd/argocd.gotmpl
@@ -99,7 +99,7 @@ configs:
           type: meta/v1/Duration
     resource.customizations.ignoreDifferences.apiextensions.k8s.io_CustomResourceDefinition: |
         jqPathExpressions:
-          - '.metadata.annotations."argocd.argoproj.io/tracking-id"'
+          - '.metadata.annotations'
     oidc.config: |
       name: Otomi
       issuer: {{ $v._derived.oidcBaseUrl }}


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
