### PR TITLE
fix: defaults for linode webhook and tempo app

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -767,7 +767,7 @@ environments:
                   memory: 64Mi
                 limits:
                   cpu: 200m
-                  memory: 256Mi
+                  memory: 1Gi
               metricsGenerator:
                 requests:
                   cpu: 50m
@@ -795,6 +795,10 @@ environments:
             autoscaling:
               ingester:
                 enabled: false
+                minReplicas: 1
+                maxReplicas: 3
+                targetCPUUtilizationPercentage: 80
+                targetMemoryUtilizationPercentage: 80
               querier:
                 enabled: false
                 minReplicas: 1

--- a/values/cert-manager-webhook-linode/cert-manager-webhook-linode.gotmpl
+++ b/values/cert-manager-webhook-linode/cert-manager-webhook-linode.gotmpl
@@ -1,10 +1,10 @@
 resources:
     requests:
         cpu: 50m
-        memory: 16Mi
+        memory: 32Mi
     limits:
         cpu: 100m
-        memory: 32Mi
+        memory: 64Mi
 deployment:
   secretName: external-dns
   secretKey: secret

--- a/values/tempo/tempo.gotmpl
+++ b/values/tempo/tempo.gotmpl
@@ -7,6 +7,12 @@ fullnameOverride: tempo
 
 ingester:
   resources: {{- $t.resources.ingester | toYaml | nindent 4 }}
+  autoscaling:
+    enabled: {{ $t.autoscaling.ingester.enabled }}
+    minReplicas: {{ $t.autoscaling.ingester.minReplicas }}
+    maxReplicas: {{ $t.autoscaling.ingester.maxReplicas }}
+    targetCPUUtilizationPercentage: {{ $t.autoscaling.ingester.targetCPUUtilizationPercentage }}
+    targetMemoryUtilizationPercentage: {{ $t.autoscaling.ingester.targetMemoryUtilizationPercentage }}
   {{- if eq $obj.type "disabled" }}
   persistence:
     enabled: true


### PR DESCRIPTION
- Improve default resource requests and limits for cert-manager webhook for linode
- Improve resource limits for Tempo and add defaults for autoscaling
