### PR TITLE
fix: ex dns resources and dns apiToken Linode

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -112,6 +112,14 @@ environments:
               username: otomi-admin
           external-dns:
             logLevel: info
+            resources:
+              limits:
+                cpu: 100m
+                memory: 128Mi
+              requests:
+                memory: 64Mi
+                cpu: 10m
+              
           falco:
             enabled: false
             driver: ebpf

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1692,6 +1692,8 @@ properties:
           logLevel:
             type: string
             default: 'info'
+          resources:
+            $ref: '#/definitions/resources'
       falco:
         additionalProperties: false
         properties:
@@ -2572,7 +2574,7 @@ properties:
             properties:
               linode:
                 properties:
-                  apiKey:
+                  apiToken:
                     type: string
                     x-secret: ''
                 required:

--- a/values/external-dns/external-dns.gotmpl
+++ b/values/external-dns/external-dns.gotmpl
@@ -44,13 +44,7 @@ podSecurityContext:
 
 priorityClassName: otomi-critical
 
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    memory: 64Mi
-    cpu: 10m
+resources: {{- $externalDns.resources | toYaml | nindent 4 }}
 
 metrics:
   enabled: true


### PR DESCRIPTION
- add defaults for external-dns resources
- fix Linode DNS apiToken
