### PR TITLE
fix: increase mem limits of apl-gitea operator

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -660,7 +660,7 @@ environments:
                   memory: 128Mi
                 limits:
                   cpu: 200m
-                  memory: 256Mi
+                  memory: 512Mi
             _rawValues: {}
           apl-keycloak-operator:
             resources:


### PR DESCRIPTION
Increase memory limits for apl-gitea-operator because the operator runs on 80% Limit constantly
