### PR TITLE
fix: default resource config

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -243,10 +243,10 @@ environments:
                   memory: 1Gi
               falcoCtlFollow:
                 requests:
-                  cpu: 20m
+                  cpu: 100m
                   memory: 16Mi
                 limits:
-                  cpu: 50m
+                  cpu: 500m
                   memory: 32Mi
               falcoCtlInstall:
                 requests:
@@ -264,23 +264,67 @@ environments:
                   memory: 256Mi
               falcoExporter:
                 requests:
-                  cpu: 20m
+                  cpu: 100m
                   memory: 16Mi
                 limits:
-                  cpu: 50m
+                  cpu: 500m
                   memory: 32Mi
           gitea:
             adminUsername: otomi-admin
             _rawValues: {}
+            resources:
+              gitea:
+                limits:
+                  cpu: 1
+                  memory: 1Gi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              memcached:
+                limits:
+                  cpu: 250m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+              memcachedMetrics:
+                limits:
+                  cpu: 200m
+                  memory: 128M
+                requests:
+                  cpu: 50m
+                  memory: 64M
+              init:
+                limits:
+                  cpu: 400m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
           grafana:
             enabled: false
             resources:
-              requests:
-                cpu: 100m
-                memory: 128Mi
-              limits:
-                cpu: 500m
-                memory: 256Mi
+              grafana:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+              downloadDashboards:
+                limits:
+                  cpu: 500m
+                  memory: 100Mi
+                requests:
+                  cpu: 200m
+                  memory: 50Mi
+              sidecar:
+                limits:
+                  cpu: 500m
+                  memory: 100Mi
+                requests:
+                  cpu: 200m
+                  memory: 50Mi                
             _rawValues: {}
           harbor:
             enabled: false
@@ -332,7 +376,7 @@ environments:
                 limits:
                   cpu: 500m
                   memory: 256Mi
-              registry-controller:
+              registryController:
                 requests:
                   cpu: 100m
                   memory: 256Mi
@@ -365,12 +409,27 @@ environments:
             maxBodySize: 1024m
             maxBodySizeBytes: 1073741824
             resources:
-              requests:
-                cpu: 200m
-                memory: 512Mi
-              limits:
-                cpu: "2"
-                memory: 2Gi
+              controller:
+                requests:
+                  cpu: 200m
+                  memory: 512Mi
+                limits:
+                  cpu: "2"
+                  memory: 2Gi
+              opentelemetry:
+                requests:
+                  cpu: 100m
+                  memory: 65Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+              defaultBackend:
+                limits:
+                  cpu: 20m
+                  memory: 20Mi
+                requests:
+                  cpu: 10m
+                  memory: 10Mi
             _rawValues: {}
           istio:
             tracing:
@@ -422,6 +481,42 @@ environments:
             _rawValues: {}
           jaeger:
             enabled: false
+            resources:
+              operator:
+                limits:
+                  cpu: 500m
+                  memory: 128Mi
+                requests:
+                  cpu: 100m
+                  memory: 32Mi
+              agent:
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+              collector:
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+              ingester:
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+              jaeger:
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
             _rawValues: {}
           keycloak:
             adminUsername: otomi-admin
@@ -567,6 +662,13 @@ environments:
                 limits:
                   cpu: 200m
                   memory: 256Mi
+              reverseProxy:
+                limits:
+                  cpu: 100m
+                  memory: 32Mi
+                requests:
+                  cpu: 50m
+                  memory: 16Mi                
             persistence:
               ingester:
                 size: 20Gi
@@ -630,8 +732,30 @@ environments:
           otomi-api:
             editorInactivityTimeout: 1
             _rawValues: {}
+            resources:
+              api:
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+              tools:
+                limits:
+                  cpu: 600m
+                  memory: 512Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
           otomi-console:
             _rawValues: {}
+            resources:
+              limits:
+                cpu: 400m
+                memory: 256Mi
+              requests:
+                cpu: 50m
+                memory: 128Mi
           otomi-operator:
             resources:
               operator:
@@ -646,34 +770,41 @@ environments:
             resources:
               operator:
                 requests:
-                  cpu: 100m
+                  cpu: 200m
                   memory: 128Mi
                 limits:
-                  cpu: 200m
-                  memory: 256Mi
+                  cpu: "1"
+                  memory: 512Mi
             _rawValues: {}
           apl-gitea-operator:
             resources:
               operator:
                 requests:
-                  cpu: 100m
+                  cpu: 200m
                   memory: 128Mi
                 limits:
-                  cpu: 200m
+                  cpu: "1"
                   memory: 512Mi
             _rawValues: {}
           apl-keycloak-operator:
             resources:
               operator:
                 requests:
-                  cpu: 100m
+                  cpu: 200m
                   memory: 128Mi
                 limits:
-                  cpu: 200m
-                  memory: 256Mi
+                  cpu: "1"
+                  memory: 512Mi
             _rawValues: {}
           promtail:
             enabled: false
+            resources:
+              requests:
+                cpu: 200m
+                memory: 256Mi
+              limits:
+                cpu: "1"
+                memory: 512Mi
             _rawValues: {}
           prometheus-blackbox-exporter:
             _rawValues: {}
@@ -691,6 +822,13 @@ environments:
             retentionSize: 4GB
             storageSize: 5Gi
             resources:
+              prometheusOperator:
+                limits:
+                  cpu: 400m
+                  memory: 256Mi
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
               prometheus:
                 requests:
                   cpu: 100m
@@ -901,10 +1039,10 @@ environments:
             replicas: 2
             resources:
               limits:
-                cpu: 500m
-                memory: 512Mi
+                cpu: "1"
+                memory: 1Gi
               requests:
-                cpu: 50m
+                cpu: 200m
                 memory: 256Mi
           harbor:
             size: 5Gi
@@ -912,10 +1050,10 @@ environments:
             coreDatabase: registry
             resources:
               limits:
-                cpu: 500m
-                memory: 512Mi
+                cpu: "1"
+                memory: 1Gi
               requests:
-                cpu: 50m
+                cpu: 200m
                 memory: 256Mi
           gitea:
             useOtomiDB: true
@@ -924,10 +1062,10 @@ environments:
             replicas: 2
             resources:
               limits:
-                cpu: 500m
-                memory: 512Mi
+                cpu: "1"
+                memory: 1Gi
               requests:
-                cpu: 50m
+                cpu: 200m
                 memory: 256Mi
         obj:
           provider:

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -275,7 +275,7 @@ environments:
             resources:
               gitea:
                 limits:
-                  cpu: 1
+                  cpu: "1"
                   memory: 1Gi
                 requests:
                   cpu: 100m

--- a/tests/fixtures/env/apps/ingress-nginx-net-a.yaml
+++ b/tests/fixtures/env/apps/ingress-nginx-net-a.yaml
@@ -12,9 +12,10 @@ apps:
         modsecurity:
             enabled: true
         resources:
-            limits:
-                cpu: 200m
-                memory: 256Mi
-            requests:
-                cpu: 100m
-                memory: 192Mi
+            controller:
+                limits:
+                    cpu: 200m
+                    memory: 256Mi
+                requests:
+                    cpu: 100m
+                    memory: 192Mi

--- a/tests/fixtures/env/apps/ingress-nginx-platform.yaml
+++ b/tests/fixtures/env/apps/ingress-nginx-platform.yaml
@@ -12,9 +12,10 @@ apps:
         modsecurity:
             enabled: true
         resources:
-            limits:
-                cpu: 200m
-                memory: 256Mi
-            requests:
-                cpu: 100m
-                memory: 192Mi
+            controller:
+                limits:
+                    cpu: 200m
+                    memory: 256Mi
+                requests:
+                    cpu: 100m
+                    memory: 192Mi

--- a/tests/fixtures/env/apps/ingress-nginx.yaml
+++ b/tests/fixtures/env/apps/ingress-nginx.yaml
@@ -9,9 +9,10 @@ apps:
         modsecurity:
             enabled: true
         resources:
-            limits:
-                cpu: 200m
-                memory: 256Mi
-            requests:
-                cpu: 100m
-                memory: 192Mi
+            controller:
+                limits:
+                    cpu: 200m
+                    memory: 256Mi
+                requests:
+                    cpu: 100m
+                    memory: 192Mi

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -292,7 +292,7 @@ changes:
       - 'otomi.isHomeMonitored'
       - 'home'
       - 'dns.provider.civo'
-  - version: 27
+  - version: 29
     relocations:
       - 'apps.harbor.resources.registry-controller': 'apps.harbor.resources.registryController'
       - 'apps.ingress-nginx.resources': 'apps.ingress-nginx.resources.controller'

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -292,3 +292,7 @@ changes:
       - 'otomi.isHomeMonitored'
       - 'home'
       - 'dns.provider.civo'
+  - version: 27
+    relocations:
+      - 'apps.harbor.resources.registry-controller': 'apps.harbor.resources.registryController'
+      - 'apps.ingress-nginx.resources': 'apps.ingress-nginx.resources.controller'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2254,8 +2254,8 @@ properties:
         properties:
           _rawValues:
             $ref: '#/definitions/rawValues'
-        resources:
-          $ref: '#/definitions/resources'
+          resources:
+            $ref: '#/definitions/resources'
         allOf:
           - anyOf:
               - not:

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -460,7 +460,12 @@ definitions:
           pullPolicy:
             $ref: '#/definitions/imagePullPolicy'
       resources:
-        $ref: '#/definitions/resources'
+        controller:
+          $ref: '#/definitions/resources'
+        opentelemetry:
+          $ref: '#/definitions/resources'
+        defaultBackend:
+          $ref: '#/definitions/resources'
       service:
         properties:
           annotations:
@@ -1776,9 +1781,13 @@ properties:
             properties:
               gitea:
                 $ref: '#/definitions/resources'
+              init:
+                $ref: '#/definitions/resources'
               postgresql:
                 $ref: '#/definitions/resources'
               memcached:
+                $ref: '#/definitions/resources'
+              memcachedMetrics:
                 $ref: '#/definitions/resources'
       grafana:
         additionalProperties: false
@@ -1794,7 +1803,12 @@ properties:
           image:
             $ref: '#/definitions/imageSimple'
           resources:
-            $ref: '#/definitions/resources'
+            grafana:
+              $ref: '#/definitions/resources'
+            sidecar:
+              $ref: '#/definitions/resources'
+            downloadDashboards:
+              $ref: '#/definitions/resources'
       harbor:
         additionalProperties: false
         properties:
@@ -1863,7 +1877,7 @@ properties:
                 $ref: '#/definitions/resources'
               registry:
                 $ref: '#/definitions/resources'
-              registry-controller:
+              registryController:
                 $ref: '#/definitions/resources'
               trivy:
                 $ref: '#/definitions/resources'
@@ -1942,6 +1956,17 @@ properties:
           enabled:
             type: boolean
             default: false
+          resources:
+            operator:
+              $ref: '#/definitions/resources'
+            agent:
+              $ref: '#/definitions/resources'
+            collector:
+              $ref: '#/definitions/resources'
+            ingester:
+              $ref: '#/definitions/resources'
+            jaeger:
+              $ref: '#/definitions/resources'
           _rawValues:
             $ref: '#/definitions/rawValues'
       keycloak:
@@ -2092,6 +2117,8 @@ properties:
                 $ref: '#/definitions/resources'
               queryFrontend:
                 $ref: '#/definitions/resources'
+              reverseProxy:
+                $ref: '#/definitions/resources'
           autoscaling:
             properties:
               ingester:
@@ -2227,6 +2254,8 @@ properties:
         properties:
           _rawValues:
             $ref: '#/definitions/rawValues'
+        resources:
+          $ref: '#/definitions/resources'
         allOf:
           - anyOf:
               - not:
@@ -2352,12 +2381,24 @@ properties:
                 $ref: '#/definitions/imageSimple'
           resources:
             properties:
+              prometheusOperator:
+                $ref: '#/definitions/resources'
               prometheus:
                 $ref: '#/definitions/resources'
               kube-state-metrics:
                 $ref: '#/definitions/resources'
               node-exporter:
                 $ref: '#/definitions/resources'
+      promtail:
+        additionalProperties: false
+        properties:
+          _rawValues:
+            $ref: '#/definitions/rawValues'
+          enabled:
+            type: boolean
+            default: false
+          resources:
+            $ref: '#/definitions/resources'
       rabbitmq:
         additionalProperties: false
         properties:

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -18,17 +18,8 @@ podDns:
     nameservers:
       - "8.8.4.4"
       - "8.8.8.8"
-resources:
-  {{ with $g | get "resources.gitea" nil }}
-    {{- toYaml . | nindent 2 }}
-  {{- else }}
-  limits:
-    cpu: 1
-    memory: 1Gi
-  requests:
-    cpu: 100m
-    memory: 128Mi
-  {{- end }}
+
+resources: {{- $g.resources.gitea | toYaml | nindent 2 }}
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -122,39 +113,17 @@ gitea:
         prometheus: system
 
 init:
-  resources:
-    limits:
-      cpu: 400m
-      memory: 256Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi
+  resources: {{- $g.resources.init | toYaml | nindent 4 }}
 
 memcached:
   # @TODO:
   image:
     tag: {{ $g | get "image.memcached.tag" "1.6.12" }}
     pullPolicy:  {{ $g | get "image.memcached.pullPolicy" "IfNotPresent" }}
-  resources:
-    {{ with $g | get "resources.memcached" nil }}
-      {{- toYaml . | nindent 4 }}
-    {{- else }}
-    limits:
-      cpu: 250m
-      memory: 256Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi
-    {{- end }}
+  resources: {{- $g.resources.memcached| toYaml | nindent 4 }}
   metrics:
     enabled: true
-    resources:
-      limits:
-        cpu: 200m
-        memory: 128M
-      requests:
-        cpu: 50m
-        memory: 64M
+    resources: {{- $g.resources.memcachedMetrics| toYaml | nindent 6 }}
     securityContext:
       enabled: true
     serviceMonitor:
@@ -184,11 +153,7 @@ postgresql:
     image:
       tag: 0.10.0
   persistence:
-    {{- if eq $v.cluster.provider "vultr" }}
-    size: 10Gi
-    {{- else }}
     size: 1Gi
-    {{- end }}
   global:
     postgresql:
       postgresqlPassword: {{ $g | get "postgresqlPassword" }}

--- a/values/harbor/harbor.gotmpl
+++ b/values/harbor/harbor.gotmpl
@@ -28,17 +28,7 @@ chartmuseum:
     tag: {{ $tag }}
   podAnnotations:
     policy.otomi.io/ignore: psp-allowed-users
-  resources:
-    {{- with $h | get "resources.chartmuseum" nil }}
-    {{- toYaml . | nindent 4 }}
-    {{- else }}
-    requests:
-      cpu: 100m 
-      memory: 128Mi
-    limits:
-      cpu: 400m
-      memory: 256Mi
-    {{- end }}
+  resources: {{- $h.resources.chartmuseum | toYaml | nindent 6 }}
 
 core:
   secretName: harbor-token-service-ca
@@ -47,17 +37,7 @@ core:
     tag: {{ $tag }}
   podAnnotations:
     policy.otomi.io/ignore: psp-allowed-users
-  resources:
-    {{- with $h | get "resources.core" nil }}
-    {{- toYaml . | nindent 4 }}
-    {{- else }}
-    limits:
-      cpu: 100m
-      memory: 512Mi
-    requests:
-      cpu: 50m
-      memory: 256Mi
-    {{- end }}
+  resources: {{- $h.resources.core | toYaml | nindent 4 }}
   secret: {{ $h | get "core.secret" nil }}
   # secretName: {{ $harborSecretName }}
   xsrfKey: {{ $h | get "core.xsrfKey" nil }}
@@ -97,17 +77,7 @@ jobservice:
     - stdout
   podAnnotations:
     policy.otomi.io/ignore: psp-allowed-users
-  resources:
-    {{- with $h | get "resources.jobservice" nil }}
-    {{- toYaml . | nindent 4 }}
-    {{- else }}
-    limits:
-      cpu: 100m
-      memory: 512Mi
-    requests:
-      cpu: 50m
-      memory: 256Mi
-    {{- end }}
+  resources: {{- $h.resources.jobservice | toYaml | nindent 4 }}
   secret: {{ $h | get "jobservice.secret" nil }}
 
 metrics:
@@ -208,17 +178,7 @@ portal:
   priorityClassName: otomi-critical
   image:
     tag: {{ $tag }}
-  resources:
-    {{- with $h | get "resources.portal" nil }}
-      {{- toYaml . | nindent 4 }}
-    {{- else }}
-    limits:
-      cpu: 400m
-      memory: 256Mi
-    requests:
-      cpu: 100m 
-      memory: 128Mi
-    {{- end }}
+  resources: {{- $h.resources.portal | toYaml | nindent 4 }}
   podAnnotations:
     policy.otomi.io/ignore: psp-allowed-users
 
@@ -230,17 +190,7 @@ redis:
   podAnnotations:
     policy.otomi.io/ignore: psp-allowed-users
   internal:
-    resources:
-      {{- with $h | get "resources.redis" nil }}
-        {{- toYaml . | nindent 6 }}
-      {{- else }}
-      limits:
-        cpu: 400m
-        memory: 256Mi
-      requests:
-        cpu: 100m 
-        memory: 128Mi
-      {{- end }}
+    resources: {{- $h.resources.redis | toYaml | nindent 6 }}
 
 registry:
   priorityClassName: otomi-critical
@@ -251,31 +201,11 @@ registry:
   registry:
     image:
       tag: {{ $tag }}
-    resources:
-      {{- with $h | get "resources.registry" nil }}
-        {{- toYaml . | nindent 6 }}
-      {{- else }}
-      limits:
-        cpu: 1000m
-        memory: 1Gi
-      requests:
-        cpu: 100m
-        memory: 128Mi
-      {{- end }}
+    resources: {{- $h.resources.registry | toYaml | nindent 6 }}
   controller:
     image:
       tag: {{ $tag }}
-    resources:
-      {{- with $h | get "resources.registry-controller" nil }}
-        {{- toYaml . | nindent 6 }}
-      {{- else }}
-      limits:
-        cpu: 100m
-        memory: 512Mi
-      requests:
-        cpu: 50m
-        memory: 256Mi
-      {{- end }}
+    resources: {{- $h.resources.registryController | toYaml | nindent 6 }}
   relativeurls: false
   credentials:
     username: {{ $h.registry.credentials.username }}

--- a/values/ingress-nginx/ingress-nginx.gotmpl
+++ b/values/ingress-nginx/ingress-nginx.gotmpl
@@ -28,7 +28,7 @@ controller:
     patch:
       priorityClassName: otomi-critical
   useComponentLabel: true
-  resources: {{- $n.resources | toYaml | nindent 4 }}
+  resources: {{- $n.resources.controller | toYaml | nindent 4 }}
   podAnnotations:
     policy.otomi.io/ignore: psp-privileged
   opentelemetry:
@@ -38,13 +38,7 @@ controller:
       runAsGroup: 65534
       runAsNonRoot: true
       allowPrivilegeEscalation: false
-    resources:
-      requests:
-        cpu: 100m
-        memory: 65Mi
-      limits:
-        cpu: 500m
-        memory: 256Mi
+    resources: {{- $n.resources.opentelemetry | toYaml | nindent 6 }}
   replicaCount: 2
   minAvailable: 1
   autoscaling:
@@ -135,13 +129,7 @@ defaultBackend:
   enabled: true
   useComponentLabel: true
   priorityClassName: otomi-critical
-  resources:
-    limits:
-      cpu: 20m
-      memory: 20Mi
-    requests:
-      cpu: 10m
-      memory: 10Mi
+  resources: {{- $n.resources.defaultBackend | toYaml | nindent 4 }}
   service:
     omitClusterIP: true
 rbac:

--- a/values/jaeger-operator/jaeger-operator.gotmpl
+++ b/values/jaeger-operator/jaeger-operator.gotmpl
@@ -1,4 +1,5 @@
 {{- $v := .Values }}
+{{- $j:= $v.apps.jaeger }}
 {{- $version := "1.29" }}
 jaeger:
   create: true
@@ -10,13 +11,7 @@ jaeger:
         query:
           base-path: /jaeger
     agent:
-      resources:
-        limits:
-          cpu: 100m
-          memory: 128Mi
-        requests:
-          cpu: 10m
-          memory: 32Mi
+      resources: {{- $j.resources.agent | toYaml | nindent 8 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -26,36 +21,18 @@ jaeger:
     annotations:
       sidecar.istio.io/inject: "true"
     collector:
-      resources:
-        limits:
-          cpu: 100m
-          memory: 128Mi
-        requests:
-          cpu: 10m
-          memory: 32Mi
+      resources: {{- $j.resources.collector | toYaml | nindent 8 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
     ingester:
-      resources:
-        limits:
-          cpu: 100m
-          memory: 128Mi
-        requests:
-          cpu: 10m
-          memory: 32Mi
+      resources: {{- $j.resources.ingester | toYaml | nindent 8 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
     ingress:
       enabled: false
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 10m
-        memory: 32Mi
+    resources: {{- $j.resources.jaeger | toYaml | nindent 6 }}
     securityContext:
       runAsNonRoot: true
       runAsUser: 1000
@@ -64,13 +41,7 @@ jaeger:
 rbac:
   clusterRole: true
 
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 10m
-    memory: 32Mi
+resources: {{- $j.resources.operator | toYaml | nindent 2 }}
 
 securityContext:
   runAsNonRoot: true

--- a/values/loki/loki.gotmpl
+++ b/values/loki/loki.gotmpl
@@ -139,13 +139,7 @@ queryFrontend:
       - name: auth
         containerPort: 3101
         protocol: TCP
-    resources:
-      limits:
-        cpu: 100m
-        memory: 32Mi
-      requests:
-        cpu: 50m
-        memory: 16Mi
+    resources: {{- $l.resources.reverseProxy | toYaml | nindent 6 }}
     volumeMounts:
       - name: reverse-proxy-auth-config
         mountPath: /etc/reverse-proxy-conf

--- a/values/otomi-api/otomi-api.gotmpl
+++ b/values/otomi-api/otomi-api.gotmpl
@@ -12,17 +12,7 @@
 replicaCount: 1
 clusterDomainSuffix: {{ $v.cluster.domainSuffix }}
 
-resources:
-{{- with $o | get "resources.api" nil }}
-  {{- toYaml . | nindent 2 }}
-{{- else }}
-  limits:
-    cpu: 500m
-    memory: 512Mi
-  requests:
-    cpu: 100m
-    memory: 256Mi
-{{- end }}
+resources: {{- $o.resources.api | toYaml | nindent 2 }}
 
 {{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "item" "api" "v" $v "skipScript" true) }}
 
@@ -57,17 +47,7 @@ core:
 
 tools:
   {{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "item" "core" "v" $v "skipScript" true) | nindent 2 }}
-  resources:
-  {{- with $o | get "resources.tools" nil }}
-    {{- toYaml . | nindent 4 }}
-  {{- else }}
-    limits:
-      cpu: 600m
-      memory: 512Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi
-  {{- end }}
+  resources: {{- $o.resources.tools | toYaml | nindent 4 }}
   env:
     DEBUG: '*'
     VERBOSITY: '1'

--- a/values/otomi-console/otomi-console.gotmpl
+++ b/values/otomi-console/otomi-console.gotmpl
@@ -3,17 +3,7 @@
 {{- $o := $v.apps | get "otomi-console" }}
 
 replicaCount: 1
-resources:
-  {{- if (hasKey $o "resources") }}
-    {{- $o.resources | toYaml | nindent 2 }}
-  {{- else }}
-  limits:
-    cpu: 400m
-    memory: 256Mi
-  requests:
-    cpu: 50m
-    memory: 128Mi
-  {{- end }}
+resources: {{- $o.resources | toYaml | nindent 2 }}
 
 {{- tpl (readFile "../../helmfile.d/snippets/job.gotmpl") (dict "item" "console" "v" $v "skipScript" true ) }}
 

--- a/values/prometheus-operator/prometheus-operator.gotmpl
+++ b/values/prometheus-operator/prometheus-operator.gotmpl
@@ -33,13 +33,7 @@ defaultRules:
     {{ . }}: true
     {{- end }}
 prometheusOperator:
-  resources:
-    limits:
-      cpu: 400m
-      memory: 256Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi
+  resources: {{- $p.resources.prometheusOperator | toYaml | nindent 4 }}
   admissionWebhooks:
     enabled: true
     certManager:
@@ -158,13 +152,7 @@ grafana:
   namespaceOverride: grafana
   defaultDashboardsTimezone: browser
   downloadDashboards:
-    resources:
-      limits:
-        cpu: 100m
-        memory: 100Mi
-      requests:
-        cpu: 50m
-        memory: 50Mi
+    resources: {{- $g.resources.downloadDashboards | toYaml | nindent 6 }}
   image:
     {{- with $g | get "image.tag" nil }}
     tag: {{ . }}
@@ -172,13 +160,7 @@ grafana:
     pullPolicy: {{ $g | get "image.pullPolicy" "IfNotPresent" }}
   resources: {{- $g.resources | toYaml | nindent 4 }}
   sidecar:
-    resources:
-      limits:
-        cpu: 100m
-        memory: 100Mi
-      requests:
-        cpu: 50m
-        memory: 50Mi
+    resources: {{- $g.resources.sidecar | toYaml | nindent 6 }}
     dashboards:
       enabled: true
       label: release

--- a/values/promtail/promtail.gotmpl
+++ b/values/promtail/promtail.gotmpl
@@ -1,20 +1,10 @@
 {{- $v := .Values }}
-{{- $promtail := $v.apps.promtail }}
+{{- $p := $v.apps.promtail }}
 {{- $l := $v.apps | get "loki" }}
 
 nameOverride: promtail
 
-resources:
-  {{- if (hasKey $promtail "resources") }}
-    {{- $promtail.resources | toYaml | nindent 2 }}
-  {{- else }}
-  requests:
-    cpu: 100m
-    memory: 256Mi
-  limits:
-    cpu: 500m
-    memory: 384Mi
-  {{- end }}
+resources: {{- $p.resources | toYaml | nindent 4 }}
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
This PR:
- configures resource defaults for a number of apps. Design principle is NOT to specify resources in any `.gotmpl`, but instead define them in the `otomi-values` and add the defaults to the `defaults.yaml`
- optimizes resources.request for a number of apps to prevent `CPUThrottlingHigh` alerts

## Checklist

- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [x] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
