### PR TITLE
fix: determine exact k8s version step

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -367,7 +367,7 @@ jobs:
           # Cluster name must be no longer than 63 characters
       - name: Determine exact k8s version
         run: |
-          echo LINODE_K8S_VERSION=$(linode-cli lke versions-list --json | jq -ce --arg version "${{ matrix.kubernetes_versions }}" '.[] | select(.id | tostring | startswith($version)) | .id') >> $GITHUB_ENV
+          echo LINODE_K8S_VERSION=$(linode-cli lke versions-list --json | jq -ce --arg version "$(echo ${{ matrix.kubernetes_versions }} | sed -E 's/^([0-9]+\.[0-9])$/\10/')" '.[] | select(.id | tostring | startswith($version)) | .id') >> $GITHUB_ENV
       - name: Create k8s cluster for testing
         run: |
           linode-cli lke cluster-create \


### PR DESCRIPTION
This PR fixes the `integration.yml` file `determine exact k8s version` step in order to create a cluster.

### Description:
Linode currently supports versions 1.31, 1.30, and 1.29. When we try to create a cluster with version 1.30, the integration.yml file interprets it as 1.3 due to YAML truncation. This leads to filtering using startsWith(1.3), which captures the two version numbers (--k8s_version "1.31" "1.30") instead of 1.30, causing the linode-cli command/error below.

command: ` linode-cli lke cluster-create \
    --label <cluster-label> \
    --region nl-ams \
    --k8s_version "1.31" "1.30" \
    --control_plane.high_availability true \
    --node_pools.type g6-dedicated-8 --node_pools.count 3 \
    --node_pools.autoscaler.enabled true \
    --node_pools.autoscaler.max 3 \
    --node_pools.autoscaler.min 3 \
    --tags testing \
    --no-defaults
`

error: `linode-cli lke cluster-create: error: unrecognized arguments: 1.30`

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
