### PR TITLE
fix: updated helm apl chart

### DIFF
--- a/chart/apl/templates/_helpers.tpl
+++ b/chart/apl/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "otomi.name" -}}
+{{- define "apl.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "otomi.fullname" -}}
+{{- define "apl.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "otomi.chart" -}}
+{{- define "apl.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "otomi.labels" -}}
-helm.sh/chart: {{ include "otomi.chart" . }}
-{{ include "otomi.selectorLabels" . }}
+{{- define "apl.labels" -}}
+helm.sh/chart: {{ include "apl.chart" . }}
+{{ include "apl.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,8 +45,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "otomi.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "otomi.name" . }}
+{{- define "apl.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "apl.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/chart/apl/templates/job.yaml
+++ b/chart/apl/templates/job.yaml
@@ -4,8 +4,8 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "otomi.fullname" . }}
-  labels: {{- include "otomi.labels" . | nindent 4 }}
+  name: {{ include "apl.fullname" . }}
+  labels: {{- include "apl.labels" . | nindent 4 }}
 spec:
   backoffLimit: 2
   template:
@@ -13,14 +13,14 @@ spec:
       {{- with .Values.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels: {{- include "otomi.selectorLabels" . | nindent 8 }}
+      labels: {{- include "apl.selectorLabels" . | nindent 8 }}
     spec:
       dnsConfig:
           nameservers:
             - 8.8.8.8
             - 8.8.4.4
       restartPolicy: Never
-      serviceAccountName: {{ include "otomi.fullname" . }}
+      serviceAccountName: {{ include "apl.fullname" . }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
@@ -58,7 +58,7 @@ spec:
           {{- if hasKey $kms "sops" }}
           envFrom:
             - secretRef:
-                name: {{ include "otomi.fullname" . }}-sops-secrets
+                name: {{ include "apl.fullname" . }}-sops-secrets
           {{- end }}
           volumeMounts:
             - name: otomi-values

--- a/chart/apl/templates/post-job.yaml
+++ b/chart/apl/templates/post-job.yaml
@@ -3,11 +3,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "otomi.fullname" . }}-pre-delete-job
+  name: {{ include "apl.fullname" . }}-pre-delete-job
   annotations:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: hook-succeeded
-  labels: {{- include "otomi.labels" . | nindent 4 }}
+  labels: {{- include "apl.labels" . | nindent 4 }}
 spec:
   backoffLimit: 2
   ttlSecondsAfterFinished: 100
@@ -16,10 +16,10 @@ spec:
       {{- with .Values.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
-      labels: {{- include "otomi.selectorLabels" . | nindent 8 }}
+      labels: {{- include "apl.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ include "otomi.fullname" . }}
+      serviceAccountName: {{ include "apl.fullname" . }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
@@ -58,7 +58,7 @@ spec:
           {{- if hasKey $kms "sops" }}
           envFrom:
             - secretRef:
-                name: {{ include "otomi.fullname" . }}-sops-secrets
+                name: {{ include "apl.fullname" . }}-sops-secrets
           {{- end }}
           volumeMounts:
             - name: otomi-values

--- a/chart/apl/templates/rbac.yaml
+++ b/chart/apl/templates/rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "otomi.fullname" . }}
-  labels: {{- include "otomi.selectorLabels" . | nindent 8 }}
+  name: {{ include "apl.fullname" . }}
+  labels: {{- include "apl.selectorLabels" . | nindent 8 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: {{ include "otomi.fullname" . }}
+    name: {{ include "apl.fullname" . }}
     namespace: {{ .Release.Namespace }}

--- a/chart/apl/templates/serviceaccount.yaml
+++ b/chart/apl/templates/serviceaccount.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "otomi.fullname" . }}
-  labels: {{- include "otomi.labels" . | nindent 4 }}
+  name: {{ include "apl.fullname" . }}
+  labels: {{- include "apl.labels" . | nindent 4 }}
   {{- with .Values.serviceAccountAnnotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/chart/apl/templates/sops-secrets.yaml
+++ b/chart/apl/templates/sops-secrets.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "otomi.fullname" . }}-sops-secrets
+  name: {{ include "apl.fullname" . }}-sops-secrets
 type: Opaque
 data:
 {{- with $v.azure }}

--- a/chart/apl/templates/values-secrets.yaml
+++ b/chart/apl/templates/values-secrets.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-values
-  labels: {{- include "otomi.labels" . | nindent 4 }}
+  labels: {{- include "apl.labels" . | nindent 4 }}
 type: Opaque
 data:
   values.yaml: |-


### PR DESCRIPTION
This PR updates the helm _helpers.tpl to use apl instead of otomi for fullname, labels and selectorLabels values generation.