### PR TITLE
fix: knative domain-template

### DIFF
--- a/values/knative/knative-serving-cr.gotmpl
+++ b/values/knative/knative-serving-cr.gotmpl
@@ -17,6 +17,7 @@ spec:
     defaults:
       revision-timeout-seconds: "300"  # 5 minutes
       enable-service-links: "false"
+    network:
       domain-template: "{{`{{.Name}}`}}-{{`{{.Namespace}}`}}.{{`{{.Domain}}`}}"
     autoscaler:
       stable-window: 600s


### PR DESCRIPTION
Fix for APL-238. The KnativeServing CR needed updating after upgrade.
