### PR TITLE
fix: default resource config

### DIFF
--- a/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
+++ b/charts/team-ns/templates/tekton-tasks/buildpacks.yaml
@@ -1,3 +1,5 @@
+{{- $v := .Values }}
+{{- range $v.resources }}
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -85,13 +87,7 @@ spec:
     env:
       - name: CNB_PLATFORM_API
         value: "0.9"
-    computeResources:
-      limits:
-        cpu: "2"
-        memory: 2Gi
-      requests:
-        cpu: 500m
-        memory: 512Mi
+    computeResources: {{- $v.resources.buildpacksTask | toYaml | nindent 6 }}
   steps:
     - name: prepare
       computeResources: {}
@@ -202,3 +198,4 @@ spec:
       emptyDir: {}
     - name: layers-dir
       emptyDir: {}
+{{- end }}

--- a/charts/team-ns/templates/tekton-tasks/git-clone.yaml
+++ b/charts/team-ns/templates/tekton-tasks/git-clone.yaml
@@ -1,3 +1,5 @@
+{{- $v := .Values }}
+{{- range $v.resources }}
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -12,13 +14,7 @@ metadata:
     tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
 spec:
   stepTemplate:
-    computeResources:
-      limits:
-        cpu: "2"
-        memory: 2Gi
-      requests:
-        cpu: 500m
-        memory: 512Mi
+    computeResources: {{- $v.resources.gitcloneTask | toYaml | nindent 6 }}
   description: >-
     These Tasks are Git tasks to work with repositories used by other tasks
     in your Pipeline.
@@ -260,3 +256,4 @@ spec:
         printf "%s" "${RESULT_COMMITTER_DATE}" > "$(results.committer-date.path)"
         printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
         printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+{{- end }}

--- a/charts/team-ns/templates/tekton-tasks/grype.yaml
+++ b/charts/team-ns/templates/tekton-tasks/grype.yaml
@@ -1,3 +1,5 @@
+{{- $v := .Values }}
+{{- range $v.resources }}
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -12,13 +14,7 @@ metadata:
     tekton.dev/platforms: "linux/amd64,linux/arm64,linux/ppc64le,linux/390x"
 spec:
   stepTemplate:
-    computeResources:
-      limits:
-        cpu: "2"
-        memory: 2Gi
-      requests:
-        cpu: 500m
-        memory: 512Mi
+    computeResources: {{- $v.resources.grypeTask | toYaml | nindent 6 }}
   description: >-
     A vulnerability scanner for container images and filesystems.
     Works with Syft, the powerful SBOM (software bill of materials) tool for container images and filesystems.
@@ -47,3 +43,4 @@ spec:
             - "ALL"
         seccompProfile:
           type: RuntimeDefault
+{{- end }}

--- a/charts/team-ns/templates/tekton-tasks/kaniko.yaml
+++ b/charts/team-ns/templates/tekton-tasks/kaniko.yaml
@@ -1,3 +1,5 @@
+{{- $v := .Values }}
+{{- range $v.resources }}
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
@@ -12,13 +14,7 @@ metadata:
     tekton.dev/platforms: "linux/amd64,linux/arm64,linux/ppc64le"
 spec:
   stepTemplate:
-    computeResources:
-      limits:
-        cpu: "2"
-        memory: 2Gi
-      requests:
-        cpu: 500m
-        memory: 512Mi
+    computeResources: {{- $v.resources.kanikoTask | toYaml | nindent 6 }}
   description: >-
     This Task builds a simple Dockerfile with kaniko and pushes to a registry.
     This Task stores the image name and digest as results, allowing Tekton Chains to pick up
@@ -80,3 +76,4 @@ spec:
         set -e
         image="$(params.IMAGE)"
         echo -n "${image}" | tee "$(results.IMAGE_URL.path)"
+{{- end }}

--- a/charts/tekton-pipelines/templates/deployment-tekton-events-controller.yaml
+++ b/charts/tekton-pipelines/templates/deployment-tekton-events-controller.yaml
@@ -63,13 +63,7 @@ spec:
         - name: tekton-events-controller
           image: {{ .Values.events.deployment.image }}
           args: []
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 1000m
-              memory: 1000Mi
+          resources: {{- toYaml .Values.events.resources | nindent 12 }}
           volumeMounts:
             - name: config-logging
               mountPath: /etc/config-logging

--- a/charts/tekton-pipelines/templates/deployment-tekton-pipelines-controller.yaml
+++ b/charts/tekton-pipelines/templates/deployment-tekton-pipelines-controller.yaml
@@ -122,13 +122,7 @@ spec:
             runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 1000m
-              memory: 1000Mi
+          resources: {{- toYaml .Values.controller.resources | nindent 12 }}
           ports:
             - name: metrics
               containerPort: 9090

--- a/charts/tekton-pipelines/templates/deployment-tekton-pipelines-remote-resolvers.yaml
+++ b/charts/tekton-pipelines/templates/deployment-tekton-pipelines-remote-resolvers.yaml
@@ -64,13 +64,7 @@ spec:
       containers:
         - name: controller
           image: {{ .Values.remoteresolver.deployment.image }}
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 1000m
-              memory: 2Gi
+          resources: {{- toYaml .Values.controller.resources | nindent 12 }}
           ports:
             - name: metrics
               containerPort: 9090

--- a/charts/tekton-pipelines/templates/deployment-tekton-pipelines-webhook.yaml
+++ b/charts/tekton-pipelines/templates/deployment-tekton-pipelines-webhook.yaml
@@ -78,13 +78,7 @@ spec:
           # and substituted here.
           image: {{ .Values.webhook.deployment.image }}
           # Resource request required for autoscaler to take any action for a metric
-          resources:
-            requests:
-              cpu: 100m
-              memory: 100Mi
-            limits:
-              cpu: 500m
-              memory: 500Mi
+          resources: {{- toYaml .Values.events.resources | nindent 12 }}
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -20,13 +20,7 @@ controller:
                   - windows
   tolerations: []
   nodeSelector: {}
-  resources:
-    requests:
-      cpu: 100m
-      memory: 100Mi
-    limits:
-      cpu: 1000m
-      memory: 1000Mi
+  resources: {}
 # Values for tekton-pipelines-webhook
 webhook:
   deployment:
@@ -48,6 +42,7 @@ webhook:
                   - windows
   tolerations: []
   nodeSelector: {}
+  resources: {}
 # Values to amend tekton-pipelines-remote-resolvers
 remoteresolver:
   deployment:
@@ -55,14 +50,9 @@ remoteresolver:
   affinity: {}
   tolerations: []
   nodeSelector: {}
-  resources:
-    requests:
-      cpu: 100m
-      memory: 100Mi
-    limits:
-      cpu: 1000m
-      memory: 1000Mi
+  resources: {}
 
 events:
   deployment:
     image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/events:v0.53.0@sha256:340e1edd0783bdb86e396ef53499f068a42da1986a1d806ab652b448869637bd
+  resources: {}

--- a/core.yaml
+++ b/core.yaml
@@ -3,6 +3,7 @@ k8s:
   namespaces:
     - name: argocd
       app: argocd
+      disableIstioInjection: true
     - name: cert-manager
       disableIstioInjection: true
     - name: cnpg-system
@@ -109,6 +110,7 @@ k8s:
     - name: velero
       app: velero
       disablePolicyChecks: true
+      disableIstioInjection: true
     - name: otomi-pipelines
       app: tekton
       disableIstioInjection: true

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -39,6 +39,7 @@ releases:
       pipeline: otomi-task-teams
     values:
       - ../values/tekton-dashboard/tekton-dashboard-teams.gotmpl
+      - resources: {{- $team.resources.tektonDashboard | toYaml | nindent 10 }}
   - name: prometheus-{{ $teamId }}
     installed: {{ or ($team | get "managedMonitoring.grafana" false) ($team | get "managedMonitoring.alertmanager" false) }}
     namespace: team-{{ $teamId }}

--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -57,6 +57,7 @@ releases:
           namespaceOverride: null
           alertmanagerSpec:
             externalUrl: "https://alertmanager-{{ $teamId }}.{{ $domain }}"
+            resources: {{- $team.resources.alertmanager | toYaml | nindent 14 }}
             podMetadata:
               annotations:
                 sidecar.istio.io/inject: "true"
@@ -77,12 +78,14 @@ releases:
           namespaceOverride: null # team-{{ $teamId }}
           nameOverride: {{ $teamId }}-po-grafana
           fullnameOverride: {{ $teamId }}-po-grafana
+          resources: {{- $team.resources.grafana | toYaml | nindent 12 }}
           grafana.ini:
             "auth.generic_oauth":
               role_attribute_path: contains(groups[*], 'admin') && 'Admin' || contains(groups[*], 'team-admin') && 'Admin' || contains(groups[*], 'team-{{ $teamId }}') && 'Editor'{{ if not ($team | get "managedMonitoring.private" false) }} || 'Viewer'{{- end }}
             server:
               root_url: https://grafana-{{ $teamId }}.{{ $domain }}
           sidecar:
+            resources: {{- $team.resources.grafanaSidecar | toYaml | nindent 14 }}
             datasources:
               defaultDatasourceEnabled: false
             dashboards:

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -8,13 +8,6 @@ environments:
           alertmanager:
             enabled: false
             resources:
-              alertmanagerTeams:
-                requests:
-                  cpu: 10m
-                  memory: 64Mi
-                limits:
-                  cpu: 200m
-                  memory: 256Mi
               alertmanager:
                 requests:
                   cpu: 10m
@@ -25,13 +18,13 @@ environments:
             _rawValues: {}
           argocd:
             applicationSet:
-              replicas: 1
+              replicas: 2
             controller:
-              replicas: 1
+              replicas: 2
             autoscaling:
               repoServer:
                 enabled: true
-                minReplicas: 1
+                minReplicas: 2
                 maxReplicas: 5
                 targetCPUUtilizationPercentage: 80
                 targetMemoryUtilizationPercentage: 80
@@ -44,7 +37,7 @@ environments:
             resources:
               controller:
                 requests:
-                  cpu: 500m
+                  cpu: 200m
                   memory: 1Gi
                 limits:
                   cpu: "2"
@@ -59,7 +52,7 @@ environments:
               repo:
                 requests:
                   cpu: 100m
-                  memory: 512M
+                  memory: 640M
                 limits:
                   cpu: "1"
                   memory: 1Gi
@@ -80,13 +73,13 @@ environments:
               notifications:
                 requests:
                   cpu: 50m
-                  memory: 64M
+                  memory: 160M
                 limits:
                   cpu: "1"
                   memory: 1Gi
               imageUpdater:
                 requests:
-                  memory: 50Mi
+                  memory: 160Mi
                   cpu: 50m
                 limits:
                   memory: 1Gi
@@ -308,21 +301,21 @@ environments:
                   memory: 1Gi
                 requests:
                   cpu: 100m
-                  memory: 128Mi
+                  memory: 256Mi
               memcached:
                 limits:
                   cpu: 250m
                   memory: 256Mi
                 requests:
-                  cpu: 100m
+                  cpu: 10m
                   memory: 128Mi
               memcachedMetrics:
                 limits:
                   cpu: 200m
                   memory: 128M
                 requests:
-                  cpu: 50m
-                  memory: 64M
+                  cpu: 10m
+                  memory: 16M
               init:
                 limits:
                   cpu: 400m
@@ -340,21 +333,7 @@ environments:
                 limits:
                   cpu: "1"
                   memory: 1Gi
-              grafanaTeams:
-                requests:
-                  cpu: 10m
-                  memory: 128Mi
-                limits:
-                  cpu: "1"
-                  memory: 1Gi
               sidecar:
-                limits:
-                  cpu: 500m
-                  memory: 256Mi
-                requests:
-                  cpu: 10m
-                  memory: 128Mi
-              sidecarTeams:
                 limits:
                   cpu: 500m
                   memory: 256Mi
@@ -372,49 +351,49 @@ environments:
             resources:
               chartmuseum:
                 requests:
-                  cpu: 10m
+                  cpu: 20m
                   memory: 56Mi
                 limits:
                   cpu: 500m
                   memory: 512Mi
               core:
                 requests:
-                  cpu: 10m
+                  cpu: 20m
                   memory: 128Mi
                 limits:
                   cpu: 500m
                   memory: 512Mi
               jobservice:
                 requests:
-                  cpu: 10m
-                  memory: 32Mi
+                  cpu: 20m
+                  memory: 128Mi
                 limits:
                   cpu: 500m
                   memory: 512Mi
               portal:
                 requests:
-                  cpu: 10m
-                  memory: 32Mi
+                  cpu: 20m
+                  memory: 128Mi
                 limits:
                   cpu: 500m
                   memory: 512Mi
               redis:
                 requests:
-                  cpu: 100m
+                  cpu: 20m
                   memory: 128Mi
                 limits:
                   cpu: 500m
                   memory: 512Mi
               registry:
                 requests:
-                  cpu: 10m
+                  cpu: 20m
                   memory: 32Mi
                 limits:
                   cpu: 500m
                   memory: 256Mi
               registryController:
                 requests:
-                  cpu: 10m
+                  cpu: 20m
                   memory: 32Mi
                 limits:
                   cpu: 500m
@@ -429,7 +408,7 @@ environments:
               nginx:
                 requests:
                   memory: 32Mi
-                  cpu: 10m
+                  cpu: 20m
                 limits:
                   memory: 512Mi
                   cpu: 200m
@@ -493,7 +472,7 @@ environments:
             resources:
               proxy:
                 requests:
-                  cpu: 20m
+                  cpu: 5m
                   memory: 80Mi
                 limits:
                   cpu: "1"
@@ -565,18 +544,18 @@ environments:
             resources:
               keycloak:
                 requests:
-                  cpu: 200m
-                  memory: 512Mi
+                  cpu: 100m
+                  memory: 640Mi
                 limits:
                   cpu: "2"
                   memory: 2Gi
               operator:
                 requests:
                   cpu: 100m
-                  memory: 128Mi
+                  memory: 336Mi
                 limits:
                   cpu: "1"
-                  memory: 512Mi
+                  memory: 1Gi
             idp:
               alias: otomi-idp
               clientID: otomi
@@ -920,11 +899,11 @@ environments:
             enabled: false
             resources:
               requests:
-                cpu: 200m
-                memory: 256Mi
+                cpu: 50m
+                memory: 160Mi
               limits:
                 cpu: "1"
-                memory: 512Mi
+                memory: 1Gi
             _rawValues: {}
           prometheus-blackbox-exporter:
             _rawValues: {}

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -421,6 +421,8 @@ environments:
               enabled: true
               minReplicas: 2
               maxReplicas: 10
+              targetCPUUtilizationPercentage: 80
+              targetMemoryUtilizationPercentage: 80
             modsecurity:
               enabled: false
               block: false
@@ -434,7 +436,7 @@ environments:
               controller:
                 requests:
                   cpu: 100m
-                  memory: 256Mi
+                  memory: 384Mi
                 limits:
                   cpu: "2"
                   memory: 2Gi

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -875,7 +875,7 @@ environments:
                   memory: 128Mi
                 limits:
                   cpu: "1"
-                  memory: 512Mi
+                  memory: 1Gi
             _rawValues: {}
           apl-gitea-operator:
             resources:
@@ -885,7 +885,7 @@ environments:
                   memory: 128Mi
                 limits:
                   cpu: "1"
-                  memory: 512Mi
+                  memory: 1Gi
             _rawValues: {}
           apl-keycloak-operator:
             resources:
@@ -895,7 +895,7 @@ environments:
                   memory: 128Mi
                 limits:
                   cpu: "1"
-                  memory: 512Mi
+                  memory: 1Gi
             _rawValues: {}
           promtail:
             enabled: false
@@ -909,21 +909,21 @@ environments:
             _rawValues: {}
           prometheus-blackbox-exporter:
             _rawValues: {}
-          resources:
-            blackboxExporter:
-              requests:
-                cpu: 50m
-                memory: 50Mi
-              limits:
-                cpu: 250m
-                memory: 300Mi
-            sentinel:
-              requests:
-                cpu: 100m
-                memory: 32Mi
-              limits:
-                cpu: 200m
-                memory: 128Mi
+            resources:
+              blackboxExporter:
+                requests:
+                  cpu: 50m
+                  memory: 50Mi
+                limits:
+                  cpu: 250m
+                  memory: 300Mi
+              sentinel:
+                requests:
+                  cpu: 100m
+                  memory: 32Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi
           prometheus:
             enabled: false
             disabledRules:

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -115,7 +115,7 @@ environments:
                   memory: 64Mi
                 limits:
                   cpu: 100m
-                  memory: 256Mi                              
+                  memory: 256Mi
             _rawValues: {}
           cnpg:
             resources:
@@ -141,7 +141,7 @@ environments:
                 memory: 128Mi
               requests:
                 memory: 64Mi
-                cpu: 10m  
+                cpu: 10m
           falco:
             enabled: false
             driver: ebpf
@@ -725,7 +725,7 @@ environments:
                   memory: 32Mi
                 requests:
                   cpu: 50m
-                  memory: 16Mi                
+                  memory: 16Mi
             persistence:
               ingester:
                 size: 20Gi
@@ -1090,7 +1090,7 @@ environments:
             autoscaling:
               ingester:
                 enabled: false
-                minReplicas: 1
+                minReplicas: 2
                 maxReplicas: 3
                 targetCPUUtilizationPercentage: 80
                 targetMemoryUtilizationPercentage: 80

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -503,7 +503,7 @@ environments:
               pilot:
                 requests:
                   cpu: 100m
-                  memory: 128Mi
+                  memory: 192Mi
                 limits:
                   cpu: "2"
                   memory: 2Gi
@@ -634,21 +634,21 @@ environments:
               pipelinesRemoteresolver:
                 requests:
                   cpu: 100m
-                  memory: 100Mi
+                  memory: 128Mi
                 limits:
                   cpu: "1"
                   memory: 1Gi
               pipelinesEvents:
                 requests:
                   cpu: 100m
-                  memory: 100Mi
+                  memory: 128Mi
                 limits:
                   cpu: "1"
                   memory: 1Gi
               pipelinesWebhook:
                 requests:
                   cpu: 100m
-                  memory: 100Mi
+                  memory: 144Mi
                 limits:
                   cpu: "1"
                   memory: 1Gi
@@ -701,7 +701,7 @@ environments:
               querier:
                 requests:
                   cpu: 50m
-                  memory: 64Mi
+                  memory: 144Mi
                 limits:
                   cpu: 200m
                   memory: 256Mi
@@ -947,8 +947,8 @@ environments:
                   memory: 128Mi
               prometheus:
                 requests:
-                  cpu: 50m
-                  memory: 1Gi
+                  cpu: 100m
+                  memory: 2Gi
                 limits:
                   cpu: '3'
                   memory: 3Gi
@@ -1175,7 +1175,7 @@ environments:
               operator:
                 requests:
                   cpu: 10m
-                  memory: 256Mi
+                  memory: 512Mi
                 limits:
                   cpu: "1"
                   memory: 1Gi

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -985,6 +985,11 @@ environments:
             enabled: false
             collector:
               mode: deployment
+              autoscaler:
+                minReplicas: 2
+                maxReplicas: 5
+                targetCPUUtilizationPercentage: 80
+                targetMemoryUtilizationPercentage: 80
               attributes:
                 - k8s.pod.name
                 - k8s.pod.uid
@@ -997,24 +1002,24 @@ environments:
             resources:
               collector:
                 requests:
-                  cpu: 100m
-                  memory: 128Mi
+                  cpu: 50m
+                  memory: 256Mi
                 limits:
                   cpu: "1"
                   memory: 1Gi
               manager:
                 requests:
                   cpu: 50m
-                  memory: 32Mi
+                  memory: 64Mi
                 limits:
-                  cpu: 200m
+                  cpu: 500m
                   memory: 512Mi
               kubeRBACProxy:
                 requests:
                   cpu: 50m
-                  memory: 64Mi
+                  memory: 32Mi
                 limits:
-                  cpu: 500m
+                  cpu: 200m
                   memory: 128Mi
             _rawValues: {}
           sealed-secrets:
@@ -1206,7 +1211,7 @@ environments:
                 memory: 1Gi
               requests:
                 cpu: 50m
-                memory: 128Mi
+                memory: 512Mi
           harbor:
             size: 5Gi
             replicas: 2
@@ -1229,7 +1234,7 @@ environments:
                 memory: 1Gi
               requests:
                 cpu: 50m
-                memory: 128Mi
+                memory: 256Mi
         obj:
           provider:
             type: disabled

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -470,6 +470,13 @@ environments:
             egressGateway:
               enabled: false
             resources:
+              operator:
+                limits:
+                  cpu: 200m
+                  memory: 256Mi
+                requests:
+                  cpu: 20m
+                  memory: 128Mi
               proxy:
                 requests:
                   cpu: 5m
@@ -505,31 +512,10 @@ environments:
               operator:
                 limits:
                   cpu: 500m
-                  memory: 128Mi
+                  memory: 1Gi
                 requests:
                   cpu: 100m
                   memory: 128Mi
-              agent:
-                limits:
-                  cpu: 100m
-                  memory: 128Mi
-                requests:
-                  cpu: 10m
-                  memory: 32Mi
-              collector:
-                limits:
-                  cpu: 100m
-                  memory: 128Mi
-                requests:
-                  cpu: 10m
-                  memory: 32Mi
-              ingester:
-                limits:
-                  cpu: 100m
-                  memory: 128Mi
-                requests:
-                  cpu: 10m
-                  memory: 32Mi
               jaeger:
                 limits:
                   cpu: "1"
@@ -644,6 +630,20 @@ environments:
                   cpu: "1"
                   memory: 1Gi
               pipelinesRemoteresolver:
+                requests:
+                  cpu: 100m
+                  memory: 100Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+              pipelinesEvents:
+                requests:
+                  cpu: 100m
+                  memory: 100Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+              pipelinesWebhook:
                 requests:
                   cpu: 100m
                   memory: 100Mi
@@ -907,6 +907,21 @@ environments:
             _rawValues: {}
           prometheus-blackbox-exporter:
             _rawValues: {}
+          resources:
+            blackboxExporter:
+              requests:
+                cpu: 50m
+                memory: 50Mi
+              limits:
+                cpu: 250m
+                memory: 300Mi
+            sentinel:
+              requests:
+                cpu: 100m
+                memory: 32Mi
+              limits:
+                cpu: 200m
+                memory: 128Mi
           prometheus:
             enabled: false
             disabledRules:
@@ -951,15 +966,15 @@ environments:
                   memory: 256Mi
               thanosSidecar:
                 requests:
-                  cpu: 50m
+                  cpu: 10m
                   memory: 64Mi
                 limits:
                   cpu: "1"
-                  memory: 256Mi
+                  memory: 512Mi
               prometheusConfigReloader:
                 requests:
                   cpu: 10m
-                  memory: 32Mi
+                  memory: 24Mi
                 limits:
                   cpu: 100m
                   memory: 128Mi              

--- a/tests/fixtures/env/apps/ingress-nginx-platform.yaml
+++ b/tests/fixtures/env/apps/ingress-nginx-platform.yaml
@@ -19,3 +19,9 @@ apps:
                 requests:
                     cpu: 100m
                     memory: 192Mi
+        autoscaling:
+            enabled: true
+            maxReplicas: 10
+            minReplicas: 1
+            targetCPUUtilizationPercentage: 80
+            targetMemoryUtilizationPercentage: 80

--- a/tests/fixtures/env/apps/otel.yaml
+++ b/tests/fixtures/env/apps/otel.yaml
@@ -3,13 +3,18 @@ apps:
         enabled: true
         collector:
             mode: deployment
-        attributes:
-            - k8s.pod.name
-            - k8s.pod.uid
-            - k8s.deployment.name
-            - k8s.namespace.name
-            - k8s.node.name
-            - k8s.pod.start_time
+            autoscaler:
+                minReplicas: 2
+                maxReplicas: 6
+                targetCPUUtilizationPercentage: 80
+                targetMemoryUtilizationPercentage: 80
+            attributes:
+                - k8s.pod.name
+                - k8s.pod.uid
+                - k8s.deployment.name
+                - k8s.namespace.name
+                - k8s.node.name
+                - k8s.pod.start_time
         operator:
             replicaCount: 1
         resources:

--- a/tests/fixtures/env/apps/prometheus-blackbox-exporter.yaml
+++ b/tests/fixtures/env/apps/prometheus-blackbox-exporter.yaml
@@ -1,0 +1,18 @@
+apps:
+    prometheus-blackbox-exporter:
+        _rawValues: {}
+        resources:
+            blackboxExporter:
+                requests:
+                    cpu: 50m
+                    memory: 50Mi
+                limits:
+                    cpu: 250m
+                    memory: 300Mi
+            sentinel:
+                requests:
+                    cpu: 100m
+                    memory: 32Mi
+                limits:
+                    cpu: 200m
+                    memory: 128Mi

--- a/tests/fixtures/env/teams.yaml
+++ b/tests/fixtures/env/teams.yaml
@@ -63,6 +63,42 @@ teamConfig:
                 requests:
                     cpu: 10m
                     memory: 128Mi
+            buildpacksTask:
+                limits:
+                    cpu: '10'
+                    memory: 2Gi
+                requests:
+                    cpu: 500m
+                    memory: 512Mi
+            gitcloneTask:
+                limits:
+                    cpu: '2'
+                    memory: 2Gi
+                requests:
+                    cpu: 500m
+                    memory: 512Mi
+            grypeTask:
+                limits:
+                    cpu: '2'
+                    memory: 2Gi
+                requests:
+                    cpu: 500m
+                    memory: 512Mi
+            kanikoTask:
+                limits:
+                    cpu: '2'
+                    memory: 2Gi
+                requests:
+                    cpu: 500m
+                    memory: 512Mi
+            tektonDashboard:
+                limits:
+                    cpu: 101m
+                    memory: 128Mi
+                requests:
+                    cpu: 10m
+                    memory: 64Mi
+
     dev:
         id: dev
         managedMonitoring:
@@ -96,3 +132,38 @@ teamConfig:
                 requests:
                     cpu: 10m
                     memory: 128Mi
+            buildpacksTask:
+                limits:
+                    cpu: '2'
+                    memory: 2Gi
+                requests:
+                    cpu: 500m
+                    memory: 512Mi
+            gitcloneTask:
+                limits:
+                    cpu: '2'
+                    memory: 2Gi
+                requests:
+                    cpu: 500m
+                    memory: 512Mi
+            grypeTask:
+                limits:
+                    cpu: '2'
+                    memory: 2Gi
+                requests:
+                    cpu: 500m
+                    memory: 512Mi
+            kanikoTask:
+                limits:
+                    cpu: '2'
+                    memory: 2Gi
+                requests:
+                    cpu: 500m
+                    memory: 512Mi
+            tektonDashboard:
+                limits:
+                    cpu: 1000m
+                    memory: 188Mi
+                requests:
+                    cpu: 10m
+                    memory: 64Mi

--- a/tests/fixtures/env/teams.yaml
+++ b/tests/fixtures/env/teams.yaml
@@ -41,6 +41,28 @@ teamConfig:
                 - alerts
             policies:
                 - edit policies
+        resources:
+            alertmanager:
+                requests:
+                    cpu: 100m
+                    memory: 64Mi
+                limits:
+                    cpu: 200m
+                    memory: 256Mi
+            grafana:
+                requests:
+                    cpu: 10m
+                    memory: 128Mi
+                limits:
+                    cpu: '1'
+                    memory: 1Gi
+            grafanaSidecar:
+                limits:
+                    cpu: 500m
+                    memory: 256Mi
+                requests:
+                    cpu: 10m
+                    memory: 128Mi
     dev:
         id: dev
         managedMonitoring:
@@ -52,3 +74,25 @@ teamConfig:
                 - downloadCertificateAuthority
             policies:
                 - edit policies
+        resources:
+            alertmanager:
+                requests:
+                    cpu: 10m
+                    memory: 64Mi
+                limits:
+                    cpu: 200m
+                    memory: 256Mi
+            grafana:
+                requests:
+                    cpu: 10m
+                    memory: 128Mi
+                limits:
+                    cpu: '1'
+                    memory: 1Gi
+            grafanaSidecar:
+                limits:
+                    cpu: 500m
+                    memory: 256Mi
+                requests:
+                    cpu: 10m
+                    memory: 128Mi

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -299,6 +299,42 @@ changes:
       - 'apps.cert-manager.resources': 'apps.cert-manager.resources.certManager'
       - 'apps.alertmanager.resources': 'apps.alertmanager.resources.alertmanager'
       - 'apps.istio.global.proxy.resources': 'apps.istio.resources.proxy'
+      - 'apps.grafana.resources.grafanaTeams': 'teamConfig.{team}.resources.grafana'
+      - 'apps.grafana.resources.sidecarTeams': 'teamConfig.{team}.resources.grafanaSidecar'
+      - 'apps.alertmanager.resources.alertmanagerTeams': 'teamConfig.{team}.resources.alertmanager'
     deletions:
       - 'teamConfig.{team}.managedMonitoring.prometheus'
       - 'apps.grafana.resources.downloadDashboards'
+    additions:
+      - 'teamConfig.{team}.resources.alertmanager.requests.cpu': 10m
+      - 'teamConfig.{team}.resources.alertmanager.requests.memory': 64Mi
+      - 'teamConfig.{team}.resources.alertmanager.limits.cpu': 200m
+      - 'teamConfig.{team}.resources.alertmanager.limits.memory': 256Mi
+      - 'teamConfig.{team}.resources.grafana.requests.cpu': 10m
+      - 'teamConfig.{team}.resources.grafana.requests.memory': 128Mi
+      - 'teamConfig.{team}.resources.grafana.limits.cpu': '1'
+      - 'teamConfig.{team}.resources.grafana.limits.memory': 1Gi
+      - 'teamConfig.{team}.resources.buildpacksTask.requests.cpu': 200m
+      - 'teamConfig.{team}.resources.buildpacksTask.requests.memory': 128Mi
+      - 'teamConfig.{team}.resources.buildpacksTask.limits.cpu': '2'
+      - 'teamConfig.{team}.resources.buildpacksTask.limits.memory': 2Gi
+      - 'teamConfig.{team}.resources.gitcloneTask.requests.cpu': 200m
+      - 'teamConfig.{team}.resources.gitcloneTask.requests.memory': 128Mi
+      - 'teamConfig.{team}.resources.gitcloneTask.limits.cpu': '2'
+      - 'teamConfig.{team}.resources.gitcloneTask.limits.memory': 2Gi
+      - 'teamConfig.{team}.resources.grypeTask.requests.cpu': 200m
+      - 'teamConfig.{team}.resources.grypeTask.requests.memory': 128Mi
+      - 'teamConfig.{team}.resources.grypeTask.limits.cpu': '2'
+      - 'teamConfig.{team}.resources.grypeTask.limits.memory': 2Gi
+      - 'teamConfig.{team}.resources.kanikoTask.requests.cpu': 200m
+      - 'teamConfig.{team}.resources.kanikoTask.requests.memory': 128Mi
+      - 'teamConfig.{team}.resources.kanikoTask.limits.cpu': '2'
+      - 'teamConfig.{team}.resources.kanikoTask.limits.memory': 2Gi
+      - 'teamConfig.{team}.resources.tektonDashboard.requests.cpu': 10m
+      - 'teamConfig.{team}.resources.tektonDashboard.requests.memory': 64Mi
+      - 'teamConfig.{team}.resources.tektonDashboard.limits.cpu': 100m
+      - 'teamConfig.{team}.resources.tektonDashboard.limits.memory': 128Mi
+      - 'teamConfig.{team}.resources.grafanaSidecar.requests.cpu': 10m
+      - 'teamConfig.{team}.resources.grafanaSidecar.requests.memory': 128Mi
+      - 'teamConfig.{team}.resources.grafanaSidecar.limits.cpu': 200m
+      - 'teamConfig.{team}.resources.grafanaSidecar.limits.memory': 256Mi

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -299,12 +299,12 @@ changes:
       - 'apps.cert-manager.resources': 'apps.cert-manager.resources.certManager'
       - 'apps.alertmanager.resources': 'apps.alertmanager.resources.alertmanager'
       - 'apps.istio.global.proxy.resources': 'apps.istio.resources.proxy'
-      - 'apps.grafana.resources.grafanaTeams': 'teamConfig.{team}.resources.grafana'
-      - 'apps.grafana.resources.sidecarTeams': 'teamConfig.{team}.resources.grafanaSidecar'
       - 'apps.alertmanager.resources.alertmanagerTeams': 'teamConfig.{team}.resources.alertmanager'
     deletions:
       - 'teamConfig.{team}.managedMonitoring.prometheus'
       - 'apps.grafana.resources.downloadDashboards'
+      - 'apps.grafana.resources.grafanaTeams'
+      - 'apps.grafana.resources.sidecarTeams'
     additions:
       - 'teamConfig.{team}.resources.alertmanager.requests.cpu': 10m
       - 'teamConfig.{team}.resources.alertmanager.requests.memory': 64Mi
@@ -338,11 +338,3 @@ changes:
       - 'teamConfig.{team}.resources.grafanaSidecar.requests.memory': 128Mi
       - 'teamConfig.{team}.resources.grafanaSidecar.limits.cpu': 200m
       - 'teamConfig.{team}.resources.grafanaSidecar.limits.memory': 256Mi
-      - 'apps.prometheus-blackbox-exporter.resources.blackboxExporter.requests.cpu': 50m
-      - 'apps.prometheus-blackbox-exporter.resources.blackboxExporter.requests.memory': 56Mi
-      - 'apps.prometheus-blackbox-exporter.resources.blackboxExporter.limits.cpu': 250m
-      - 'apps.prometheus-blackbox-exporter.resources.blackboxExporter.limits.memory': 256Mi
-      - 'apps.prometheus-blackbox-exporter.resources.sentinel.requests.cpu': 50m
-      - 'apps.prometheus-blackbox-exporter.resources.sentinel.requests.memory': 32Mi
-      - 'apps.prometheus-blackbox-exporter.resources.sentinel.limits.cpu': 200m
-      - 'apps.prometheus-blackbox-exporter.resources.sentinel.limits.memory': 128Mi

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -338,3 +338,11 @@ changes:
       - 'teamConfig.{team}.resources.grafanaSidecar.requests.memory': 128Mi
       - 'teamConfig.{team}.resources.grafanaSidecar.limits.cpu': 200m
       - 'teamConfig.{team}.resources.grafanaSidecar.limits.memory': 256Mi
+      - 'apps.prometheus-blackbox-exporter.resources.blackboxExporter.requests.cpu': 50m
+      - 'apps.prometheus-blackbox-exporter.resources.blackboxExporter.requests.memory': 56Mi
+      - 'apps.prometheus-blackbox-exporter.resources.blackboxExporter.limits.cpu': 250m
+      - 'apps.prometheus-blackbox-exporter.resources.blackboxExporter.limits.memory': 256Mi
+      - 'apps.prometheus-blackbox-exporter.resources.sentinel.requests.cpu': 50m
+      - 'apps.prometheus-blackbox-exporter.resources.sentinel.requests.memory': 32Mi
+      - 'apps.prometheus-blackbox-exporter.resources.sentinel.limits.cpu': 200m
+      - 'apps.prometheus-blackbox-exporter.resources.sentinel.limits.memory': 128Mi

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1128,6 +1128,89 @@ definitions:
           private:
             type: boolean
             default: false
+      resources:
+        properties:
+          alertmanager:
+            additionalProperties: false
+            properties:
+              requests:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 10m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 64Mi
+                required:
+                  - cpu
+                  - memory
+              limits:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 200m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 256Mi
+                required:
+                  - cpu
+                  - memory
+          grafana:
+            additionalProperties: false
+            properties:
+              requests:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 10m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 128Mi
+                required:
+                  - cpu
+                  - memory
+              limits:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: '1'
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 1Gi
+                required:
+                  - cpu
+                  - memory
+          grafanaSidecar:
+            additionalProperties: false
+            properties:
+              requests:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 10m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 128Mi
+                required:
+                  - cpu
+                  - memory
+              limits:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 200m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 256Mi
+                required:
+                  - cpu
+                  - memory
       networkPolicy:
         ingressPrivate:
           title: Enable filtering of ingress traffic inside the cluster
@@ -1469,8 +1552,6 @@ properties:
             $ref: '#/definitions/imageSimple'
           resources:
             properties:
-              alertmanagerTeams:
-                $ref: '#/definitions/resources'
               alertmanger:
                 $ref: '#/definitions/resources'
       argocd:
@@ -1785,10 +1866,6 @@ properties:
             grafana:
               $ref: '#/definitions/resources'
             sidecar:
-              $ref: '#/definitions/resources'
-            grafanaTeams:
-              $ref: '#/definitions/resources'
-            sidecarTeams:
               $ref: '#/definitions/resources'
       harbor:
         additionalProperties: false

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1184,6 +1184,141 @@ definitions:
                 required:
                   - cpu
                   - memory
+          buildpacksTask:
+            additionalProperties: false
+            properties:
+              requests:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 200m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 128Mi
+                required:
+                  - cpu
+                  - memory
+              limits:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: '2'
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 2Gi
+                required:
+                  - cpu
+                  - memory
+          gitcloneTask:
+            additionalProperties: false
+            properties:
+              requests:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 200m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 128Mi
+                required:
+                  - cpu
+                  - memory
+              limits:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: '2'
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 2Gi
+                required:
+                  - cpu
+                  - memory
+          grypeTask:
+            additionalProperties: false
+            properties:
+              requests:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 200m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 128Mi
+                required:
+                  - cpu
+                  - memory
+              limits:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: '2'
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 2Gi
+                required:
+                  - cpu
+                  - memory
+          kanikoTask:
+            additionalProperties: false
+            properties:
+              requests:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 200m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 128Mi
+                required:
+                  - cpu
+                  - memory
+              limits:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: '2'
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 2Gi
+                required:
+                  - cpu
+                  - memory
+          tektonDashboard:
+            additionalProperties: false
+            properties:
+              requests:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: 10m
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 64Mi
+                required:
+                  - cpu
+                  - memory
+              limits:
+                additionalProperties: false
+                properties:
+                  cpu:
+                    $ref: '#/definitions/cpuQuantity'
+                    default: '100m'
+                  memory:
+                    $ref: '#/definitions/memoryQuantity'
+                    default: 128Mi
+                required:
+                  - cpu
+                  - memory
           grafanaSidecar:
             additionalProperties: false
             properties:
@@ -2007,6 +2142,8 @@ properties:
                 $ref: '#/definitions/resources'
               proxy:
                 $ref: '#/definitions/resources'
+              operator:
+                $ref: '#/definitions/resources'
       jaeger:
         additionalProperties: false
         properties:
@@ -2015,12 +2152,6 @@ properties:
             default: false
           resources:
             operator:
-              $ref: '#/definitions/resources'
-            agent:
-              $ref: '#/definitions/resources'
-            collector:
-              $ref: '#/definitions/resources'
-            ingester:
               $ref: '#/definitions/resources'
             jaeger:
               $ref: '#/definitions/resources'
@@ -2200,6 +2331,10 @@ properties:
               pipelinesController:
                 $ref: '#/definitions/resources'
               pipelinesRemoteresolver:
+                $ref: '#/definitions/resources'
+              pipelinesEvents:
+                $ref: '#/definitions/resources'
+              pipelinesWebhook:
                 $ref: '#/definitions/resources'
               triggersInterceptors:
                 $ref: '#/definitions/resources'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -427,7 +427,23 @@ definitions:
             type: string
             default: '0.01'
       autoscaling:
-        $ref: '#/definitions/autoscalingEnabled'
+        additionalProperties: false
+        properties:
+          enabled:
+            default: true
+            type: boolean
+          maxReplicas:
+            type: integer
+            default: 10
+          minReplicas:
+            type: integer
+            default: 1
+          targetCPUUtilizationPercentage:
+            type: integer
+            default: 80
+          targetMemoryUtilizationPercentage:
+            type: integer
+            default: 80
       maxBodySize:
         type: string
         default: 1024m
@@ -2789,6 +2805,20 @@ properties:
                   - deployment
                   - daemonset
                   - statefulset
+              autoscaler:
+                properties:
+                  maxReplicas:
+                    type: integer
+                    default: 5
+                  minReplicas:
+                    type: integer
+                    default: 2
+                  targetCPUUtilizationPercentage:
+                    type: integer
+                    default: 80
+                  targetMemoryUtilizationPercentage:
+                    type: integer
+                    default: 80
               attributes:
                 type: array
                 title: Kubernetes Attributes

--- a/values/argocd/argocd.gotmpl
+++ b/values/argocd/argocd.gotmpl
@@ -11,7 +11,12 @@ global:
   {{- end }}
 # ApplicationSet Controller
 applicationSet:
-  replicas: {{ $a.applicationSet.replicas }} 
+  replicas: {{ $a.applicationSet.replicas }}
+  pdb:
+    enabled: true
+    labels:
+      app.kubernetes.io/component: applicationset-controller
+    minAvailable: 1
   resources: {{- $a.resources.applicationSet | toYaml | nindent 4 }}
   metrics:
     enabled: true
@@ -22,7 +27,12 @@ applicationSet:
 
 # Application Controller
 controller:
-  replicas: {{ $a.controller.replicas }} 
+  replicas: {{ $a.controller.replicas }}
+  pdb:
+    enabled: true
+    labels:
+      app.kubernetes.io/component: application-controller
+    minAvailable: 1
   resources: {{- $a.resources.controller | toYaml | nindent 4 }}
   metrics:
     enabled: true

--- a/values/ingress-nginx/ingress-nginx.gotmpl
+++ b/values/ingress-nginx/ingress-nginx.gotmpl
@@ -43,8 +43,8 @@ controller:
     enabled: {{ $n.autoscaling.enabled }}
     minReplicas: {{ $n.autoscaling.minReplicas }}
     maxReplicas: {{ $n.autoscaling.maxReplicas }}
-    targetCPUUtilizationPercentage: 60
-    targetMemoryUtilizationPercentage: 75
+    targetCPUUtilizationPercentage: {{ $n.autoscaling.targetCPUUtilizationPercentage }}
+    targetMemoryUtilizationPercentage: {{ $n.autoscaling.targetMemoryUtilizationPercentage }}
   priorityClassName: otomi-critical
   extraArgs:
     v: 3

--- a/values/istio-operator/istio-operator.gotmpl
+++ b/values/istio-operator/istio-operator.gotmpl
@@ -5,6 +5,9 @@ hub: istio
 
 operatorNamespace: istio-operator
 
+operator:
+  resources: {{- $i.resources.operator | toYaml | nindent 6 }}
+
 {{- with .Values.otomi | get "globalPullSecret" nil }}
 imagePullSecrets:
   - otomi-pullsecret-global

--- a/values/jaeger-operator/jaeger-operator.gotmpl
+++ b/values/jaeger-operator/jaeger-operator.gotmpl
@@ -10,26 +10,8 @@ jaeger:
       options:
         query:
           base-path: /jaeger
-    agent:
-      resources: {{- $j.resources.agent | toYaml | nindent 8 }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-      sidecarSecurityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
     annotations:
       sidecar.istio.io/inject: "true"
-    collector:
-      resources: {{- $j.resources.collector | toYaml | nindent 8 }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-    ingester:
-      resources: {{- $j.resources.ingester | toYaml | nindent 8 }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
     ingress:
       enabled: false
     resources: {{- $j.resources.jaeger | toYaml | nindent 6 }}

--- a/values/otel-operator/otel-operator-raw.gotmpl
+++ b/values/otel-operator/otel-operator-raw.gotmpl
@@ -74,6 +74,11 @@ resources:
               - jaeger
               {{- end }}
       mode: {{ $o.collector.mode }}
+      autoscaler:
+        minReplicas: {{ $o.collector.autoscaler.minReplicas }}
+        maxReplicas: {{ $o.collector.autoscaler.maxReplicas }}
+        targetCPUUtilization: {{ $o.collector.autoscaler.targetCPUUtilizationPercentage }}
+        targetMemoryUtilization: {{ $o.collector.autoscaler.targetMemoryUtilizationPercentage }}
       resources: {{- $o.resources.collector | toYaml | nindent 8 }}
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRole

--- a/values/prometheus-blackbox-exporter/prometheus-blackbox-exporter.gotmpl
+++ b/values/prometheus-blackbox-exporter/prometheus-blackbox-exporter.gotmpl
@@ -7,22 +7,10 @@ persistence:
   size: 1Gi
 usePassword: false
 
-resources:
-  requests:
-    cpu: 50m
-    memory: 50Mi
-  limits:
-    cpu: 250m
-    memory: 300Mi
+resources: {{- $pbe.resources.blackboxExporter| toYaml | nindent 4 }}
 
 sentinel:
-  resources:
-    requests:
-      cpu: 100m
-      memory: 32Mi
-    limits:
-      cpu: 200m
-      memory: 128Mi
+  resources: {{- $pbe.resources.sentinel | toYaml | nindent 6 }}
 
 config:
   modules:

--- a/values/prometheus-blackbox-exporter/prometheus-blackbox-exporter.gotmpl
+++ b/values/prometheus-blackbox-exporter/prometheus-blackbox-exporter.gotmpl
@@ -7,7 +7,7 @@ persistence:
   size: 1Gi
 usePassword: false
 
-resources: {{- $pbe.resources.blackboxExporter| toYaml | nindent 4 }}
+resources: {{- $pbe.resources.blackboxExporter | toYaml | nindent 4 }}
 
 sentinel:
   resources: {{- $pbe.resources.sentinel | toYaml | nindent 6 }}

--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -63,3 +63,9 @@ grafana:
 alertmanager:
   serviceMonitor:
     selfMonitor: false
+
+prometheus:
+  thanosService:
+    enabled: false
+  thanosServiceMonitor:
+    enabled: false

--- a/values/prometheus-operator/prometheus-operator-team.gotmpl
+++ b/values/prometheus-operator/prometheus-operator-team.gotmpl
@@ -59,12 +59,7 @@ grafana:
     enabled: false
   defaultDashboardsEnabled: false
   plugins: []
-  resources: {{- $g.resources.grafanaTeams | toYaml | nindent 4 }}
-  sidecar: 
-    resources: {{- $g.resources.sidecarTeams | toYaml | nindent 6 }}
 
 alertmanager:
   serviceMonitor:
     selfMonitor: false
-  alertmanagerSpec:
-    resources: {{- $a.resources.alertmanagerTeams | toYaml | nindent 6 }}

--- a/values/tekton-dashboard/tekton-dashboard-teams.gotmpl
+++ b/values/tekton-dashboard/tekton-dashboard-teams.gotmpl
@@ -2,8 +2,6 @@
 {{- $v := .Values }}
 {{- $t := $v.apps.tekton }}
 
-resources: {{- $t.resources.dashboard | toYaml | nindent 2 }}
-
 teamId: {{ $teamId }}
 
 args:

--- a/values/tekton-pipelines/tekton-pipelines.gotmpl
+++ b/values/tekton-pipelines/tekton-pipelines.gotmpl
@@ -6,3 +6,9 @@ controller:
 
 remoteresolver:
   resources: {{- $t.resources.pipelinesRemoteresolver | toYaml | nindent 4 }}
+
+events:
+  resources: {{- $t.resources.pipelinesEvents | toYaml | nindent 4 }}
+
+webhook:
+  resources: {{- $t.resources.pipelinesWebhook | toYaml | nindent 4 }}

--- a/values/tempo/tempo.gotmpl
+++ b/values/tempo/tempo.gotmpl
@@ -6,6 +6,7 @@
 fullnameOverride: tempo
 
 ingester:
+  replicas: {{ $t.autoscaling.ingester.minReplicas }}
   resources: {{- $t.resources.ingester | toYaml | nindent 4 }}
   autoscaling:
     enabled: {{ $t.autoscaling.ingester.enabled }}
@@ -21,6 +22,7 @@ ingester:
   {{- end }}
 
 distributor:
+  replicas: {{ $t.autoscaling.distributor.minReplicas }}
   resources: {{- $t.resources.distributor | toYaml | nindent 4 }}
   autoscaling:
     enabled: {{ $t.autoscaling.distributor.enabled }}
@@ -38,6 +40,7 @@ compactor:
   resources: {{- $t.resources.compactor | toYaml | nindent 4 }}
 
 querier:
+  replicas: {{ $t.autoscaling.querier.minReplicas }}
   resources: {{- $t.resources.querier | toYaml | nindent 4 }}
   autoscaling:
     enabled: {{ $t.autoscaling.querier.enabled }}
@@ -47,6 +50,7 @@ querier:
     targetMemoryUtilizationPercentage: {{ $t.autoscaling.querier.targetMemoryUtilizationPercentage }}
 
 queryFrontend:
+  replicas: {{ $t.autoscaling.queryFrontend.minReplicas }}
   resources: {{- $t.resources.queryFrontend | toYaml | nindent 4 }}
   autoscaling:
     enabled: {{ $t.autoscaling.queryFrontend.enabled }}


### PR DESCRIPTION
Scope:

- Make resources of platform Pods running in a Team namespace configurable per Team
- HA for argoCD application-controller
- `disableIstioInjection` for argoCD
- add PDBs for ArgoCD app and appset controllers
- Optimize auto scaling of ingress-nginx controllers
- Add autoscaling for otel collector
- remove unused Jaeger values

related PRs: https://github.com/linode/apl-api/pull/566

## Checklist

- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [x] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [x] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
