### PR TITLE
fix: remove duplicate imagePullPolicy

### DIFF
--- a/charts/prometheus-msteams/templates/deployment.yaml
+++ b/charts/prometheus-msteams/templates/deployment.yaml
@@ -57,7 +57,6 @@ spec:
           {{- with .Values.container.additionalArgs }}
 {{ toYaml . | indent 12 }}
           {{- end}}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - name: http
             containerPort: {{ .Values.container.port }}


### PR DESCRIPTION
This PR fixes a duplicate key in the Deployment of `prometheus-msteams`.