### PR TITLE
fix: upgrade istio to 1.22.5

### DIFF
--- a/values/istio-operator/istio-operator.gotmpl
+++ b/values/istio-operator/istio-operator.gotmpl
@@ -1,7 +1,7 @@
 {{- $v := .Values }}
 {{- $i := $v.apps | get "istio" }}
 hub: istio
-# tag: {{ $i | get "image.tag" "1.15.1" }}
+tag: 1.22.5
 
 operatorNamespace: istio-operator
 


### PR DESCRIPTION
Istio version `1.22.1` broke the serviceentries used for the egress filtering. These changes have been reverted in the `1.22.5` patch release.
