### PR TITLE
fix: add init container for oauth2 proxy

### DIFF
--- a/charts/oauth2-proxy/templates/deployment.yaml
+++ b/charts/oauth2-proxy/templates/deployment.yaml
@@ -100,6 +100,9 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
+{{- if .Values.extraInitContainers }}
+  {{- toYaml .Values.extraInitContainers | nindent 6 }}
+{{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ include "oauth2-proxy.version" . }}"

--- a/charts/oauth2-proxy/values.yaml
+++ b/charts/oauth2-proxy/values.yaml
@@ -215,6 +215,8 @@ extraContainers: []
   #  - name: my-sidecar
   #    image: nginx:latest
 
+extraInitContainers: []
+
 priorityClassName: ""
 
 # hostAliases is a list of aliases to be added to /etc/hosts for network name resolution

--- a/values/keycloak-operator/keycloak-operator-cr.gotmpl
+++ b/values/keycloak-operator/keycloak-operator-cr.gotmpl
@@ -47,7 +47,7 @@ spec:
           emptyDir: {}
         initContainers:
         - name: init-container-theme-copy # Otomi branding init container
-          image: docker.io/linode/apl-console:{{ $v.versions.console }}
+          image: docker.io/linode/apl-console:v{{ $v.versions.console }}
           resources: {{ $k.resources.keycloak | toYaml  | nindent 12 }}
           command: 
           - sh 

--- a/values/oauth2-proxy/oauth2-proxy.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy.gotmpl
@@ -79,6 +79,12 @@ extraVolumeMounts:
     mountPath: /etc/oauth2-proxy/error.html
     subPath: error.html
 
+extraInitContainers:
+  - name: wait-for-keycloak
+    image: docker.io/linode/apl-console:{{ $v.versions.console }}
+    command: ["/bin/sh","-c"]
+    args: ["while [ $(curl -sw '%{http_code}' http:///keycloak-service.keycloak.svc.cluster.local:8080 -o /dev/null) -ne 200 ]; do sleep 2; echo 'Waiting for Keycloak...'; done"]
+
 {{- with .Values.otomi | get "globalPullSecret" nil }}
 imagePullSecrets:
   - name: otomi-pullsecret-global

--- a/values/oauth2-proxy/oauth2-proxy.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy.gotmpl
@@ -81,7 +81,7 @@ extraVolumeMounts:
 
 extraInitContainers:
   - name: wait-for-keycloak
-    image: docker.io/linode/apl-console:{{ $v.versions.console }}
+    image: docker.io/linode/apl-console:v{{ $v.versions.console }}
     command: ["/bin/sh","-c"]
     args: ["while [ $(curl -sw '%{http_code}' http:///keycloak-service.keycloak.svc.cluster.local:8080 -o /dev/null) -ne 200 ]; do sleep 2; echo 'Waiting for Keycloak...'; done"]
 

--- a/values/oauth2-proxy/oauth2-proxy.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy.gotmpl
@@ -83,7 +83,7 @@ extraInitContainers:
   - name: wait-for-keycloak
     image: docker.io/linode/apl-console:v{{ $v.versions.console }}
     command: ["/bin/sh","-c"]
-    args: ["while [ $(curl -sw '%{http_code}' http:///keycloak-service.keycloak.svc.cluster.local:8080 -o /dev/null) -ne 200 ]; do sleep 2; echo 'Waiting for Keycloak...'; done"]
+    args: ["while [ $(curl -sw '%{http_code}' {{ $v._derived.oidcBaseUrl }} -o /dev/null) -ne 200 ]; do sleep 2; echo 'Waiting for Keycloak OIDC Issuer URL'; done"]
 
 {{- with .Values.otomi | get "globalPullSecret" nil }}
 imagePullSecrets:


### PR DESCRIPTION
Add an additional init container to oauth2 proxy to check availability of OIDC issuer URL before starting oauth2 proxy
