### PR TITLE
fix: byo certificate name

### DIFF
--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -33,7 +33,7 @@
 {{- if eq $cm.issuer "externally-managed-tls-secret" }}
   {{- $tlsSecretName = $cm.externallyManagedTlsSecretName }}
 {{- else if eq $cm.issuer "byo-wildcard-cert" }}
-  {{- $tlsSecretName = "byo-wildcard-cert" }}
+  {{- $tlsSecretName = "otomi-byo-wildcard-cert" }}
 {{- end -}}
 
 {{- if and (not (env "CI")) (not (env "VALUES_INPUT")) (hasKey $v.cluster "k8sContext") }}


### PR DESCRIPTION
This PR fixes a bug that slipped through while refactoring the certificate secret names with different providers. As a workaround, the certificate can currently be copied into the new name during the installation process.