### PR TITLE
fix: queue processors and controller resource defaults

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -17,10 +17,12 @@ environments:
                   memory: 256Mi              
             _rawValues: {}
           argocd:
+            controllerStatusProcessors: 20
+            controllerOperationProcessors: 10
             applicationSet:
               replicas: 1
             controller:
-              replicas: 2
+              replicas: 1
             autoscaling:
               repoServer:
                 enabled: true
@@ -38,10 +40,10 @@ environments:
               controller:
                 requests:
                   cpu: 200m
-                  memory: 512Mi
+                  memory: 1Gi
                 limits:
                   cpu: "2"
-                  memory: 2Gi
+                  memory: 4Gi
               server:
                 requests:
                   cpu: 100m

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1521,6 +1521,12 @@ properties:
         properties:
           _rawValues:
             $ref: '#/definitions/rawValues'
+          controllerStatusProcessors:
+            default: 20
+            type: integer
+          controllerOperationProcessors:
+            default: 10
+            type: integer
           applicationSet:
             replicas:
               default: 1

--- a/values/argocd/argocd.gotmpl
+++ b/values/argocd/argocd.gotmpl
@@ -127,9 +127,9 @@ configs:
   params:
     server.insecure: true # nginx terminates tls
     # -- Number of application status processors
-    controller.status.processors: 10
+    controller.status.processors: {{ $a.controllerStatusProcessors }}
     # -- Number of application operation processors
-    controller.operation.processors: 5
+    controller.operation.processors: {{ $a.controllerOperationProcessors }}
 
   rbac:
     policy.csv: |


### PR DESCRIPTION
During testing with 66 applications, the controller had insufficient memory and got status `OOMKilled`. This PR increases the memory limits for the ArgoCD controller and adds queue processors to the schema for optimization when using more applications. The queue processors are set back to the ArgoCD defaults.
