### PR TITLE
feat: remove optional private grafana

### DIFF
--- a/helmfile.d/helmfile-60.teams.yaml
+++ b/helmfile.d/helmfile-60.teams.yaml
@@ -79,7 +79,10 @@ releases:
           fullnameOverride: {{ $teamId }}-po-grafana
           grafana.ini:
             "auth.generic_oauth":
-              role_attribute_path: contains(groups[*], 'admin') && 'Admin' || contains(groups[*], 'platform-admin') && 'Admin' || contains(groups[*], 'team-{{ $teamId }}') && 'Editor'{{ if not ($team | get "managedMonitoring.private" false) }} || 'Viewer'{{- end }}
+              role_attribute_path: >-
+                contains(groups[*], 'admin') && 'Admin' ||
+                contains(groups[*], 'platform-admin') && 'Admin' ||
+                contains(groups[*], 'team-{{ $teamId }}') && 'Editor'
             server:
               root_url: https://grafana-{{ $teamId }}.{{ $domain }}
             analytics:

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -312,3 +312,6 @@ changes:
     relocations:
       - 'oidc.adminGroupID': 'oidc.platformAdminGroupID'
       - 'oidc.teamAdminGroupID': 'oidc.allTeamsAdminGroupID'
+  - version: 31
+    deletions:
+      - 'teamConfig.{team}.managedMonitoring.private'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1141,9 +1141,6 @@ definitions:
           alertmanager:
             type: boolean
             default: false
-          private:
-            type: boolean
-            default: false
       networkPolicy:
         ingressPrivate:
           title: Enable filtering of ingress traffic inside the cluster


### PR DESCRIPTION
This PR drops the per-team setting `managedMonitoring.private`, which was mainly intended to maintain backwards compatibility to the behavior before the multitenancy became the default, despite being potentially confusing.

## Checklist

- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [x] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [x] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.

