### PR TITLE
fix: remove additional cluster logic

### DIFF
--- a/chart/otomi/values.schema.json
+++ b/chart/otomi/values.schema.json
@@ -4271,29 +4271,6 @@
     "otomi": {
       "additionalProperties": false,
       "properties": {
-        "additionalClusters": {
-          "type": "array",
-          "items": {
-            "title": "Additional cluster",
-            "description": "A k8s cluster managed by Otomi.",
-            "properties": {
-              "domainSuffix": {
-                "$ref": "#/definitions/domain"
-              },
-              "name": {
-                "$ref": "#/definitions/idName"
-              },
-              "provider": {
-                "$ref": "#/definitions/provider"
-              }
-            },
-            "required": [
-              "domainSuffix",
-              "name",
-              "provider"
-            ]
-          }
-        },
         "adminPassword": {
           "type": "string",
           "x-secret": "{{ randAlphaNum 20 }}"

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -63,10 +63,6 @@ oidc:
     allTeamsAdminGroupID: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     teamAdminGroupID: xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 otomi:
-    additionalClusters:
-        - domainSuffix: demo.eks.otomi.cloud
-          name: demo
-          provider: custom
     globalPullSecret:
         username: otomi
     hasExternalDNS: true

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -315,3 +315,4 @@ changes:
   - version: 31
     deletions:
       - 'teamConfig.{team}.managedMonitoring.private'
+      - 'otomi.additionalClusters'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2989,22 +2989,6 @@ properties:
   otomi:
     additionalProperties: false
     properties:
-      additionalClusters:
-        type: array
-        items:
-          title: Additional cluster
-          description: A k8s cluster managed by Otomi.
-          properties:
-            domainSuffix:
-              $ref: '#/definitions/domain'
-            name:
-              $ref: '#/definitions/idName'
-            provider:
-              $ref: '#/definitions/provider'
-          required:
-            - domainSuffix
-            - name
-            - provider
       adminPassword:
         type: string
         x-secret: '{{ randAlphaNum 20 }}'


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
