### PR TITLE
APL-300: added policy setting to external-dns values

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -1312,6 +1312,7 @@ environments:
         dns:
           domainFilters: []
           zoneIdFilters: []
+          policy: upsert-only
         ingress:
           platformClass:
             className: platform

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -2725,6 +2725,13 @@ properties:
         items:
           type: string
         type: array
+      policy:
+        description: Modify how DNS records are synchronized between sources and providers.
+        type: string
+        enum:
+          - upsert-only
+          - sync
+        default: upsert-only
       provider:
         description: The DNS provider managing the domains.
         oneOf:

--- a/values/external-dns/external-dns.gotmpl
+++ b/values/external-dns/external-dns.gotmpl
@@ -20,6 +20,7 @@ provider: {{ $provider }}
 domainFilters: {{ $dns | get "domainFilters" | toYaml | nindent 2 }}
 zoneIdFilters: {{ $dns | get "zoneIdFilters" list | toYaml | nindent 2 }}
 annotationFilter: "externaldns=true"
+policy: {{ $dns.policy }}
 logLevel: {{ $externalDns | get "logLevel" }}
 dryRun: false
 crd:


### PR DESCRIPTION
This PR adds the `policy` setting supported by external-dns to the APL values schema. This does not change the default behavior. For now this is not yet added to API / console.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [x] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [x] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
