### PR TITLE
fix: set datasource for trivy dashboard to default

### DIFF
--- a/charts/grafana-dashboards/trivy-teams/trivy-teams.json
+++ b/charts/grafana-dashboards/trivy-teams/trivy-teams.json
@@ -1447,11 +1447,7 @@
         "type": "datasource"
       },
       {
-        "current": {
-          "selected": false,
-          "text": "team-demo",
-          "value": "team-demo"
-        },
+        "current": {},
         "datasource": {
           "type": "prometheus",
           "uid": "$datasource"

--- a/charts/grafana-dashboards/trivy-teams/trivy-teams.json
+++ b/charts/grafana-dashboards/trivy-teams/trivy-teams.json
@@ -95,6 +95,7 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "last"
@@ -102,9 +103,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -163,6 +166,7 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "last"
@@ -170,9 +174,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -231,6 +237,7 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "last"
@@ -238,9 +245,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -299,6 +308,7 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "last"
@@ -306,9 +316,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -367,6 +379,7 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "last"
@@ -374,9 +387,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -435,6 +450,7 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "last"
@@ -442,9 +458,11 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -549,7 +567,7 @@
           }
         ]
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -730,7 +748,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "11.2.2",
       "targets": [
         {
           "datasource": {
@@ -854,11 +872,13 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 15,
             "gradientMode": "opacity",
@@ -867,6 +887,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 2,
             "pointSize": 5,
@@ -969,8 +990,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "blue",
@@ -1037,8 +1057,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "yellow",
@@ -1105,8 +1124,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "orange",
@@ -1173,8 +1191,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1241,8 +1258,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "text",
@@ -1339,8 +1355,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "blue",
@@ -1406,8 +1421,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": [
     "Prometheus",
     "Trivy"
@@ -1417,8 +1431,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus-platform",
-          "value": "Prometheus-platform"
+          "text": "default",
+          "value": "default"
         },
         "hide": 0,
         "includeAll": false,
@@ -1428,15 +1442,15 @@
         "query": "prometheus",
         "queryValue": "",
         "refresh": 1,
-        "regex": "Prometheus-platform",
+        "regex": "default",
         "skipUrlSync": false,
         "type": "datasource"
       },
       {
         "current": {
           "selected": false,
-          "text": "team-orange",
-          "value": "team-orange"
+          "text": "team-demo",
+          "value": "team-demo"
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
The trivy Team dashboard in Grafana needs to use the default datasource in case Thanos is enabled.
