### PR TITLE
chore: versions

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,5 +1,5 @@
-api: 3.1.0
-console: 3.1.0
+api: main
+console: main
 consoleLogin: v3.0.0
-tasks: 3.4.0
+tasks: main
 tools: 2.7.0


### PR DESCRIPTION
Since we upgraded base images, we need to see new images are still compatible with the whole platform.