### PR TITLE
feat: added cors for ouath2-proxy ingress

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -1324,6 +1324,7 @@ environments:
           hasExternalIDP: false
           isMultitenant: true
           nodeSelector: {}
+          isPreInstalled: false
         users: []
         e2e:
           enabled: false

--- a/values/oauth2-proxy/oauth2-proxy-raw.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy-raw.gotmpl
@@ -11,6 +11,11 @@ resources:
     metadata:
       annotations:
         externaldns: "true"
+        {{- with $v.otomi.isPreInstalled }}
+        nginx.ingress.kubernetes.io/cors-allow-origin: "https://cloud.linode.com,https://cloud.staging.linode.com,https://cloud.dev.linode.com"
+        nginx.ingress.kubernetes.io/enable-cors: "true"
+        nginx.ingress.kubernetes.io/cors-allow-methods: "GET,OPTIONS"
+        {{- end }}
         {{- with $v | get "dns.provider.linode" nil }}
         # Check Linode Api documentation for allowed values in seconds: https://developers-linode.netlify.app/api/v4/domains
         external-dns.alpha.kubernetes.io/ttl: "1h"


### PR DESCRIPTION
This PR adds CORS related annotations to the oauth2-proxy ingress so that it can be queried from cloud manager.