### PR TITLE
fix: anti affinity between gitea keycloak and master redis

### DIFF
--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -28,6 +28,19 @@ podDns:
 
 resources: {{- $g.resources.gitea | toYaml | nindent 2 }}
 
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: otomi.io/affinity
+                operator: In
+                values:
+                  - anti
+          topologyKey: kubernetes.io/hostname
+        weight: 100
+
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
@@ -120,6 +133,8 @@ init:
   resources: {{- $g.resources.init | toYaml | nindent 4 }}
 
 statefulset:
+  labels:
+    otomi.io/affinity: "anti"
   env:
     - name: RCLONE_CONFIG_GITEA_TYPE
       value: s3

--- a/values/keycloak-operator/keycloak-operator-cr.gotmpl
+++ b/values/keycloak-operator/keycloak-operator-cr.gotmpl
@@ -35,8 +35,23 @@ spec:
     strictBackchannel: false
   unsupported:
     podTemplate:
+      metadata:
+        labels:
+          otomi.io/affinity: "anti"
       spec:
         priorityClassName: otomi-critical
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: otomi.io/affinity
+                        operator: In
+                        values:
+                          - anti
+                  topologyKey: kubernetes.io/hostname
+                weight: 100
         containers: #
         - volumeMounts:
             - name: theme-volume

--- a/values/keycloak-operator/keycloak-operator-cr.gotmpl
+++ b/values/keycloak-operator/keycloak-operator-cr.gotmpl
@@ -35,23 +35,8 @@ spec:
     strictBackchannel: false
   unsupported:
     podTemplate:
-      metadata:
-        labels:
-          otomi.io/affinity: "anti"
       spec:
         priorityClassName: otomi-critical
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              - podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                      - key: otomi.io/affinity
-                        operator: In
-                        values:
-                          - anti
-                  topologyKey: kubernetes.io/hostname
-                weight: 100
         containers: #
         - volumeMounts:
             - name: theme-volume

--- a/values/oauth2-proxy/oauth2-proxy.gotmpl
+++ b/values/oauth2-proxy/oauth2-proxy.gotmpl
@@ -110,7 +110,20 @@ redis:
       sidecar.istio.io/inject: "false"
     priorityClassName: otomi-critical
     resources: {{- $r.resources.master | toYaml | nindent 6 }}
-
+    podLabels:
+      otomi.io/affinity: "anti"
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: otomi.io/affinity
+                    operator: In
+                    values:
+                      - anti
+              topologyKey: kubernetes.io/hostname
+            weight: 100
   replica:
     persistence:
       size: {{ $r.persistence.replica.size }}


### PR DESCRIPTION
This PR introduces anti affinity between Gitea and the Oauth2 master redis pods to assure all pods are scheduled on different nodes.
