### PR TITLE
fix: naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@
 
 ## Getting started
 
-### Step 1: [Install the Application Platform](https://apl-docs.net/docs/get-started/installation/overview)
-Install the Application Platform on Linode Kubernetes Engine (LKE) or any other conformant Kubernetes cluster.
+### Step 1: [Install the App Platform](https://apl-docs.net/docs/get-started/installation/overview)
+Install the App Platform on Linode Kubernetes Engine (LKE) or any other conformant Kubernetes cluster.
 
 ### Step 2: [Follow the post installation steps ](https://apl-docs.net/docs/get-started/installation/post-installation-steps)
-Configure the Application Platform for your use case.
+Configure the App Platform for your use case.
 
-### Step 3: [Explore the Application Platform using the Labs](https://apl-docs.net/docs/get-started/labs/overview)
-Explore the Application Platform with a comprehensive set of hands-on labs.
+### Step 3: [Explore the App Platform using the Labs](https://apl-docs.net/docs/get-started/labs/overview)
+Explore the App Platform with a comprehensive set of hands-on labs.
 
 ## Akamai Application Platform supports
 

--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -209,7 +209,7 @@ export const printWelcomeMessage = async (): Promise<void> => {
   const message = `
   ########################################################################################################################################
   #
-  #  The Application Platform console is available at https://console.${domainSuffix}
+  #  The App Platform console is available at https://console.${domainSuffix}
   #
   #  Obtain login credentials by using the below commands:
   #      kubectl get secret ${secretName} -n keycloak -o jsonpath='{.data.username}' | base64 -d


### PR DESCRIPTION
Remove "Application Platform" as an accepted variation of the product name
