### PR TITLE
Apl 356

### DIFF
--- a/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
@@ -59,9 +59,9 @@ spec:
 
         # Cloning the values
         {{- if .Values.cloneUnsecure }}
-        git clone -c http.sslVerify=false --depth 2 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url
+        git clone -c http.sslVerify=false --depth 2 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url"
         {{- else }}
-        git clone --depth 2 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url
+        git clone --depth 2 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url"
         {{- end }}
 
         # Checking if the next steps should run or skipped 

--- a/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
@@ -48,7 +48,7 @@ spec:
 
         # Reading gitea credentials
         GITEA_USERNAME=$(cat /etc/gitea-credentials/username)
-        GITEA_PASSWORD=$(cat /etc/gitea-credentials/password)
+        GITEA_PASSWORD=$(cat /etc/gitea-credentials/password | jq -s -R -r @uri )
 
         # Getting the full repository url
         export fullRepoUrl=$(params["repoUrl"])
@@ -59,11 +59,9 @@ spec:
 
         # Cloning the values
         {{- if .Values.cloneUnsecure }}
-        echo: APL356 Debug
-        git clone -c http.sslVerify=false --depth 2 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url"
+        git clone -c http.sslVerify=false --depth 2 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url
         {{- else }}
-        echo: APL356 Debug
-        git clone --depth 2 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url"
+        git clone --depth 2 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url
         {{- end }}
 
         # Checking if the next steps should run or skipped 

--- a/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-git-clone.yaml
@@ -59,8 +59,10 @@ spec:
 
         # Cloning the values
         {{- if .Values.cloneUnsecure }}
+        echo: APL356 Debug
         git clone -c http.sslVerify=false --depth 2 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url"
         {{- else }}
+        echo: APL356 Debug
         git clone --depth 2 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url"
         {{- end }}
 

--- a/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
@@ -57,9 +57,9 @@ spec:
 
         # Cloning the values
         {{- if .Values.cloneUnsecure }}
-        git clone -c http.sslVerify=false --depth 1 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url $ENV_DIR
+        git clone -c http.sslVerify=false --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
         {{- else}}
-        git clone --depth 1 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url $ENV_DIR
+        git clone --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
         {{- end }}
     - name: test
       computeResources: {}

--- a/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
@@ -49,7 +49,7 @@ spec:
         git config --global --add safe.directory '*'
         # Reading gitea credentials
         GITEA_USERNAME=$(cat /etc/gitea-credentials/username)
-        GITEA_PASSWORD=$(cat /etc/gitea-credentials/password)
+        GITEA_PASSWORD=$(cat /etc/gitea-credentials/password | jq -s -R -r @uri )
 
         # Parsing the repo url
         export fullRepoUrl=$(params["repoUrl"])
@@ -57,11 +57,9 @@ spec:
 
         # Cloning the values
         {{- if .Values.cloneUnsecure }}
-        echo: APL356 Debug
-        git clone -c http.sslVerify=false --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
+        git clone -c http.sslVerify=false --depth 1 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url $ENV_DIR
         {{- else}}
-        echo: APL356 Debug
-        git clone --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
+        git clone --depth 1 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url $ENV_DIR
         {{- end }}
     - name: test
       computeResources: {}

--- a/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task-teams.yaml
@@ -57,8 +57,10 @@ spec:
 
         # Cloning the values
         {{- if .Values.cloneUnsecure }}
+        echo: APL356 Debug
         git clone -c http.sslVerify=false --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
         {{- else}}
+        echo: APL356 Debug
         git clone --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
         {{- end }}
     - name: test

--- a/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
@@ -57,8 +57,10 @@ spec:
 
         # Cloning the values
         {{- if .Values.cloneUnsecure }}
+        echo: APL356 Debug
         git clone -c http.sslVerify=false --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
         {{- else}}
+        echo: APL356 Debug
         git clone --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
         {{- end }}
     - name: bootstrap

--- a/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
@@ -49,7 +49,7 @@ spec:
         git config --global --add safe.directory '*'
         # Reading gitea credentials
         GITEA_USERNAME=$(cat /etc/gitea-credentials/username)
-        GITEA_PASSWORD=$(cat /etc/gitea-credentials/password)
+        GITEA_PASSWORD=$(cat /etc/gitea-credentials/password | jq -s -R -r @uri )
 
         # Parsing the repo url
         export fullRepoUrl=$(params["repoUrl"])
@@ -57,11 +57,9 @@ spec:
 
         # Cloning the values
         {{- if .Values.cloneUnsecure }}
-        echo: APL356 Debug
-        git clone -c http.sslVerify=false --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
+        git clone -c http.sslVerify=false --depth 1 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url $ENV_DIR
         {{- else}}
-        echo: APL356 Debug
-        git clone --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
+        git clone --depth 1 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url $ENV_DIR
         {{- end }}
     - name: bootstrap
       computeResources: {}

--- a/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
+++ b/charts/otomi-pipelines/templates/tekton-otomi-task.yaml
@@ -57,9 +57,9 @@ spec:
 
         # Cloning the values
         {{- if .Values.cloneUnsecure }}
-        git clone -c http.sslVerify=false --depth 1 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url $ENV_DIR
+        git clone -c http.sslVerify=false --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
         {{- else}}
-        git clone --depth 1 http://$GITEA_USERNAME:$GITEA_PASSWORD@$url $ENV_DIR
+        git clone --depth 1 "http://${GITEA_USERNAME}:${GITEA_PASSWORD}@$url" $ENV_DIR
         {{- end }}
     - name: bootstrap
       computeResources: {}

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: APL-356
+api: 3.2.0
 console: 3.2.0
 consoleLogin: v3.0.0
 tasks: 3.4.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 3.2.0
+api: APL-356
 console: 3.2.0
 consoleLogin: v3.0.0
 tasks: 3.4.0


### PR DESCRIPTION
This PR is part of the needed fixes for [APL-356](https://jira.linode.com/browse/APL-356)

In this PR we url-encode the gitea password so it does not break the `git clone` command.

To be tested in conjunction with [PR579](https://github.com/linode/apl-api/pull/579)