### PR TITLE
feat: removed uneeded tag

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -203,7 +203,6 @@ jobs:
             --node_pools.autoscaler.max 3 \
             --node_pools.autoscaler.min 3 \
             --tags testing \
-            --tags delete_me_tonight \
             --no-defaults
       - name: Retrieve cluster id
         run: echo "LINODE_CLUSTER_ID=$(linode-cli lke clusters-list --json | jq -ce '.[] | select(.label | startswith("${{ env.LINODE_CLUSTER_NAME }}")) | .id')" >> $GITHUB_ENV


### PR DESCRIPTION
This PR is part of the new cluster clean-up logic. Instead of deleting clusters with the delete_me_tonight tag, it will delete all the clusters except the ones having the do_not_delete tag.
Related PR: https://bits.linode.com/APL/apl-gh-actions/pull/4
