### PR TITLE
feat: APL-372 updated cnpg endpointurl

### DIFF
--- a/charts/otomi-db/templates/cluster.yaml
+++ b/charts/otomi-db/templates/cluster.yaml
@@ -46,6 +46,10 @@ spec:
         secretAccessKey:
           name: minio-creds
           key: MINIO_SECRET_KEY
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
   {{- end }}
   {{- if eq .Values.backup.type "linode" }}
   backup:

--- a/charts/otomi-db/templates/cluster.yaml
+++ b/charts/otomi-db/templates/cluster.yaml
@@ -64,6 +64,10 @@ spec:
         secretAccessKey:
           name: linode-creds
           key: S3_STORAGE_KEY
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
   {{- end }}
 {{- end }}
 

--- a/values/gitea/gitea-otomi-db.gotmpl
+++ b/values/gitea/gitea-otomi-db.gotmpl
@@ -24,7 +24,7 @@ backup:
 {{- if eq $obj.type "linode" }}
   linode:
     destinationPath: "s3://{{ $obj.linode.buckets.cnpg }}/gitea"
-    endpointURL: https://{{ $obj.linode.buckets.cnpg }}.{{ $obj.linode.region }}.linodeobjects.com
+    endpointURL: https://{{ $obj.linode.region }}.linodeobjects.com
 {{- end }}
 {{- end }}
 {{- end }}

--- a/values/harbor/harbor-otomi-db.gotmpl
+++ b/values/harbor/harbor-otomi-db.gotmpl
@@ -23,7 +23,7 @@ backup:
 {{- if eq $obj.type "linode" }}
   linode:
     destinationPath: "s3://{{ $obj.linode.buckets.cnpg }}/harbor"
-    endpointURL: https://{{ $obj.linode.buckets.cnpg }}.{{ $obj.linode.region }}.linodeobjects.com
+    endpointURL: https://{{ $obj.linode.region }}.linodeobjects.com
 {{- end }}
 {{- end }}
 {{- end }}

--- a/values/keycloak/keycloak-otomi-db.gotmpl
+++ b/values/keycloak/keycloak-otomi-db.gotmpl
@@ -24,7 +24,7 @@ backup:
 {{- if eq $obj.type "linode" }}
   linode:
     destinationPath: "s3://{{ $obj.linode.buckets.cnpg }}/keycloak"
-    endpointURL: https://{{ $obj.linode.buckets.cnpg }}.{{ $obj.linode.region }}.linodeobjects.com
+    endpointURL: https://{{ $obj.linode.region }}.linodeobjects.com
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR fixes the "backup size growing indefinitely" issue.
This PR updates the endpointUrl for the object storages where the backups and WAL files are saved.
Fixing this result in a successful backup and also a successful enforcement of the retention policy.
In this PR we are also enabling the WAL and Data compression to make the backup smaller.
Tested on a new cluster by setting the retention policy to 1 day. 
