### PR TITLE
feat: fixed apl-tools patch image generation

### DIFF
--- a/.github/workflows/cloudtty-build-push.yml
+++ b/.github/workflows/cloudtty-build-push.yml
@@ -49,7 +49,7 @@ jobs:
             echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
             echo OLD_VERSION = ${OLD_VERSION}
             echo NEW_VERSION = ${NEW_VERSION}
-          elif git diff-tree --no-commit-id --name-only ${{ github.sha }} -r | grep -q "tools\/Dockerfile-tty"; then
+          elif git diff-tree --no-commit-id --name-only ${{ github.sha }} -r | grep -q -x "tools\/Dockerfile-tty"; then
             # No special tag found, but changes were made to the tools/Dockerfile-tty so will upgrade the patch version.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$3 = $3 + 1} {print $0}')"
             echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV

--- a/.github/workflows/otomi-tools-build-push.yaml
+++ b/.github/workflows/otomi-tools-build-push.yaml
@@ -63,7 +63,7 @@ jobs:
             echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
             echo OLD_VERSION = ${OLD_VERSION}
             echo NEW_VERSION = ${NEW_VERSION}
-          elif git diff-tree --no-commit-id --name-only ${{ github.sha }} -r | grep -q "tools\/Dockerfile"; then
+          elif git diff-tree --no-commit-id --name-only ${{ github.sha }} -r | grep -q -x "tools\/Dockerfile"; then
             # No special tag found, but changes were made to the tools/Dockerfile so will upgrade the patch version.
             NEW_VERSION="$(echo ${OLD_VERSION} | awk -F. -v OFS=. '{$3 = $3 + 1} {print $0}')"
             echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV


### PR DESCRIPTION
This PR fixes the apl-tools patch image generation.
For the time being a change of files named `*tools/Dockerfile*` would trigger a build of the apl-tools image.
This PR fixes it so that only changes in `tools/Dockerfile` (the Dockerfile for apl-tools) trigger the build and push.