### PR TITLE
fix: install minio based on enabled

### DIFF
--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -197,7 +197,7 @@ environments:
           metrics-server:
             enabled: {{ $a | get "metrics-server.enabled" (has $provider (list "custom" "linode")) }}
           minio:
-            enabled: {{ $a | get "minio.enabled" false }}
+            enabled: {{ $a.minio.enabled }}
           prometheus-msteams:
             enabled: {{ and ($a | get "alertmanager.enabled" false) (or (has "msteams" ($v | get "alerts.receivers" list)) (has "msteams" ($v | get "home.receivers" list))) }}
           sealed-secrets:

--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -195,9 +195,9 @@ environments:
           istio:
             enabled: true
           metrics-server:
-            enabled: {{ $a | get "metrics-server.enabled" (has $provider (list "custom" "aws" "digitalocean" "linode")) }}
+            enabled: {{ $a | get "metrics-server.enabled" (has $provider (list "custom" "linode")) }}
           minio:
-            enabled: {{ eq $obj.type "minioLocal" }}
+            enabled: {{ $a | get "minio.enabled" false }}
           prometheus-msteams:
             enabled: {{ and ($a | get "alertmanager.enabled" false) (or (has "msteams" ($v | get "alerts.receivers" list)) (has "msteams" ($v | get "home.receivers" list))) }}
           sealed-secrets:


### PR DESCRIPTION
Install minio app only when minio is enabled as this is the default workflow for enabling apps.

## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
