### PR TITLE
fix: removed external-secrets charts from chart-index

### DIFF
--- a/chart/chart-index/Chart.yaml
+++ b/chart/chart-index/Chart.yaml
@@ -32,9 +32,6 @@ dependencies:
   - name: external-dns
     version: 6.20.4
     repository: https://charts.bitnami.com/bitnami
-  - name: external-secrets
-    version: 0.6.1
-    repository: https://charts.external-secrets.io
   - name: gitea
     version: 5.0.0
     repository: https://dl.gitea.io/charts


### PR DESCRIPTION
Removed external-secrets from chart-index since we are not using the chart anymore.
See pipeline error: https://github.com/linode/apl-core/actions/runs/12287670240/job/34290108929#step:7:49