### PR TITLE
ci: update chart version index for a single chart

### DIFF
--- a/ci/src/update-helm-chart-deps.mjs
+++ b/ci/src/update-helm-chart-deps.mjs
@@ -66,6 +66,7 @@ async function main() {
     }
 
     for (const dependency of chart.dependencies) {
+      const currentDependencyVersion = dependency.version
       if (dependencyNameFilter.length != 0 && !dependencyNameFilter.includes(dependency.name)) {
         console.log(
           `Skipping updates for dependency: ${dependency.name} due to dependencyNameFilter: ${dependencyNameFilter} `,
@@ -155,6 +156,8 @@ async function main() {
       } catch (error) {
         console.error('Error updating dependencies:', error)
       } finally {
+        // restore this version so it does not populate to the next chart update
+        dependency.version = currentDependencyVersion
         if (ciCreateFeatureBranch) {
           // Reset to the main branch for the next dependency
           await $`git checkout ${baseBranch}`

--- a/ci/src/update-helm-chart-deps.mjs
+++ b/ci/src/update-helm-chart-deps.mjs
@@ -7,13 +7,6 @@ import yaml from 'js-yaml'
 import semver from 'semver'
 import { $ } from 'zx'
 
-/**
- *
- * @param {string} currentVersion
- * @param {string} version
- * @param {string} allowedUpgradeType
- * @returns boolean
- */
 export function isVersionApplicable(currentVersion, version, allowedUpgradeType) {
   if (semver.lte(version, currentVersion)) {
     return false // Ignore versions that are <= current version


### PR DESCRIPTION
I noticed that some PRs created by Helm chart bot have more that one dependency version number updated in the Chart.yaml file. Example: https://github.com/linode/apl-core/pull/1863/files#diff-1c892db7344feb10640b6353e7452859ca22f33e57737e167a4cc55d23ba91f2

This PR fixes that issue.

Testing:
In local environment: at ci/.env:
```
CI_UPDATE_TYPE='minor'
CI_HELM_CHART_NAME_FILTER='[]'
CI_GH_CREATE_PR='false'
CI_GIT_BASELINE_BRANCH='APL-11-1'
CI_GIT_LOCAL_BRANCH_ONLY='true'
```

then run
```
src/update-helm-chart-deps.mjs
```
then 
```
git checkout ci-update-sealed-secrets-to-2.17.0
```

```
gd HEAD~1
```

You should see only one version updated
```
 dependencies:
   - name: argo-cd
     version: 6.7.3
@@ -60,7 +44,7 @@ dependencies:
     version: 6.11.2
     repository: https://grafana.github.io/helm-charts
   - name: sealed-secrets
-    version: 2.14.1
+    version: 2.17.0
     repository: https://bitnami-labs.github.io/sealed-secrets/
   - name: tekton-pipeline
     version: 1.0.2
```