### PR TITLE
feat: cnpg upgrade fix

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -1335,4 +1335,4 @@ environments:
           upgrade:
             version: main
         # TODO: update this when schema version changes
-        version: 32
+        version: 33

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -1335,4 +1335,4 @@ environments:
           upgrade:
             version: main
         # TODO: update this when schema version changes
-        version: 33
+        version: 32

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -1260,6 +1260,7 @@ environments:
             _rawValues: {}
         databases:
           keycloak:
+            imageName: null
             imported: false
             size: 5Gi
             replicas: 2
@@ -1271,6 +1272,7 @@ environments:
                 cpu: "1"
                 memory: 192Mi
           harbor:
+            imageName: null
             size: 5Gi
             replicas: 2
             coreDatabase: registry
@@ -1282,6 +1284,7 @@ environments:
                 cpu: "1"
                 memory: 192Mi
           gitea:
+            imageName: null
             useOtomiDB: true
             imported: false
             size: 5Gi

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -120,4 +120,4 @@ status:
         deployingVersion: 0.21.0
         status: deployed
         version: 0.21.0
-version: 33
+version: 32

--- a/tests/fixtures/env/settings.yaml
+++ b/tests/fixtures/env/settings.yaml
@@ -120,4 +120,4 @@ status:
         deployingVersion: 0.21.0
         status: deployed
         version: 0.21.0
-version: 32
+version: 33

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -319,6 +319,10 @@ changes:
   - version: 32
     deletions:
       - 'teamConfig.{team}.managedMonitoring.prometheus'
+    additions:
+      - databases.keycloak.imageName: ghcr.io/cloudnative-pg/postgresql:15.3
+      - databases.gitea.imageName: ghcr.io/cloudnative-pg/postgresql:15.3
+      - databases.harbor.imageName: ghcr.io/cloudnative-pg/postgresql:15.3
     mutations:
       - databases.keycloak.resources.limits.memory: '192Mi'
       - databases.keycloak.resources.limits.cpu: '1'
@@ -332,3 +336,8 @@ changes:
       - databases.harbor.resources.limits.cpu: '1'
       - databases.harbor.resources.requests.memory: '192Mi'
       - databases.harbor.resources.requests.cpu: '1'
+  - version: 33
+    mutations:
+      - databases.keycloak.imageName: ghcr.io/cloudnative-pg/postgresql:15.10
+      - databases.gitea.imageName: ghcr.io/cloudnative-pg/postgresql:15.10
+      - databases.harbor.imageName: ghcr.io/cloudnative-pg/postgresql:15.10

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -336,8 +336,3 @@ changes:
       - databases.harbor.resources.limits.cpu: '1'
       - databases.harbor.resources.requests.memory: '192Mi'
       - databases.harbor.resources.requests.cpu: '1'
-  - version: 33
-    mutations:
-      - databases.keycloak.imageName: ghcr.io/cloudnative-pg/postgresql:15.10
-      - databases.gitea.imageName: ghcr.io/cloudnative-pg/postgresql:15.10
-      - databases.harbor.imageName: ghcr.io/cloudnative-pg/postgresql:15.10

--- a/values/gitea/gitea-otomi-db.gotmpl
+++ b/values/gitea/gitea-otomi-db.gotmpl
@@ -10,6 +10,10 @@ storage:
   size: {{ $gdb.size }}
 instances: {{ $gdb.replicas }}
 
+{{- with $gdb.imageName }}
+imageName: {{ . }}
+{{- end }}
+
 postgresql:
   parameters:
     max_connections: "32"

--- a/values/harbor/harbor-otomi-db.gotmpl
+++ b/values/harbor/harbor-otomi-db.gotmpl
@@ -9,6 +9,10 @@ storage:
   size: {{ $hdb.size }}
 instances: {{ $hdb.replicas }}
 
+{{- with $hdb.imageName }}
+imageName: {{ . }}
+{{- end }}
+
 postgresql:
   parameters:
     max_connections: "32"

--- a/values/keycloak/keycloak-otomi-db.gotmpl
+++ b/values/keycloak/keycloak-otomi-db.gotmpl
@@ -10,6 +10,10 @@ storage:
   size: {{ $kdb.size }}
 instances: {{ $kdb.replicas }}
 
+{{- with $kdb.imageName }}
+imageName: {{ . }}
+{{- end }}
+
 postgresql:
   parameters:
     max_connections: "32"


### PR DESCRIPTION
For both this PRs([APL-282](https://github.com/linode/apl-core/pull/1784), [APL-281](https://github.com/linode/apl-core/pull/1856)) the upgrade was tested separately, so we missed the argo application sync error:
![image](https://github.com/user-attachments/assets/268e51b3-75f1-402c-9523-1acbaab81c29)
Apparently we can update the postrgresql image version or the postrgresql parameters but not both at the same time.

In order to solve this I propose we run 2 values schema changes in 2 different minor version.
The first (version: 32) will pin the postgresql image version for the platform apps(harbor, gitea, keycloak) to version 15.3(actual version) and will update its resource requests/limits along with some [postgresql parameters](https://cloudnative-pg.io/documentation/1.16/postgresql_conf/#the-postgresql-section).  

The next changes (version: 33), can update the imageName value using mutations  .