### PR TITLE
fix: ensure rootDir and increase retry timeout

### DIFF
--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -12,7 +12,7 @@ import { getCurrentVersion, getImageTag, writeValuesToFile } from 'src/common/va
 import { HelmArguments, getParsedArgs, helmOptions, setParsedArgs } from 'src/common/yargs'
 import { ProcessOutputTrimmed } from 'src/common/zx-enhance'
 import { Argv, CommandModule } from 'yargs'
-import { $ } from 'zx'
+import { $, cd } from 'zx'
 import { applyAsApps } from './apply-as-apps'
 import {
   cloneOtomiChartsInGitea,
@@ -146,12 +146,11 @@ const apply = async (): Promise<void> => {
   if (!argv.label && !argv.file) {
     await retry(async (bail) => {
       try {
+        cd(rootDir)
         await applyAll()
       } catch (e) {
         d.error(e)
-        await $`helm uninstall wait-for-otomi-realm -n maintenance`.nothrow().quiet()
-        await $`kubectl delete job wait-for-otomi-realm -n maintenance`.nothrow().quiet()
-        d.info(`Retrying in ${retryOptions.maxRetryTime} ms`)
+        d.info(`Retrying in ${retryOptions.maxTimeout} ms`)
         throw e
       }
     }, retryOptions)

--- a/src/common/k8s.ts
+++ b/src/common/k8s.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-loop-func */
 /* eslint-disable no-await-in-loop */
+import { AppsV1Api, CoreV1Api, CustomObjectsApi, KubeConfig, V1Secret } from '@kubernetes/client-node'
+import { V1ResourceRequirements } from '@kubernetes/client-node/dist/gen/model/v1ResourceRequirements'
 import retry, { Options } from 'async-retry'
 import { AnyAaaaRecord, AnyARecord } from 'dns'
 import { resolveAny } from 'dns/promises'
@@ -16,8 +18,6 @@ import { env } from './envalid'
 import { hfValues } from './hf'
 import { parser } from './yargs'
 import { askYesNo } from './zx-enhance'
-import { AppsV1Api, CoreV1Api, CustomObjectsApi, KubeConfig, V1Secret } from '@kubernetes/client-node'
-import { V1ResourceRequirements } from '@kubernetes/client-node/dist/gen/model/v1ResourceRequirements'
 
 export const secretId = `secret/otomi/${DEPLOYMENT_PASSWORDS_SECRET}`
 
@@ -243,7 +243,7 @@ type WaitTillAvailableOptions = Options & {
 
 export const waitTillGitRepoAvailable = async (repoUrl): Promise<void> => {
   const retryOptions: Options = {
-    retries: 10,
+    retries: 20,
     maxTimeout: 30000,
   }
   const d = terminal('common:k8s:waitTillGitRepoAvailable')

--- a/src/common/k8s.ts
+++ b/src/common/k8s.ts
@@ -253,7 +253,7 @@ export const waitTillGitRepoAvailable = async (repoUrl): Promise<void> => {
       // the ls-remote exist with zero even if repo is empty
       await $`git ls-remote ${repoUrl}`
     } catch (e) {
-      d.warn(e.message)
+      d.warn(`The ${repoUrl} is not yet reachable. Retrying in ${retryOptions.maxTimeout} ms`)
       throw e
     }
   }, retryOptions)


### PR DESCRIPTION
This code change:
- ensures setting correct current working directory 
- increases waitTillGitRepoAvailable timeout to accommodate DNS and Certificate request delays
- fixes the `Retrying in undefined ms` log message
- improve readability of error message once performing `git ls-remote` command


Testing methodology:
- I was able to reproduce the issue by deploying the following the `APL-449-reproduce` branch (https://github.com/linode/apl-core/pull/1884)
- I tested the change by deploying the `APL-449-test branch`, which exactly the same as this PR except I lowered down the  retries parameter.
