### PR TITLE
fix: removed repoUrl variable from error message

### DIFF
--- a/src/common/k8s.ts
+++ b/src/common/k8s.ts
@@ -253,7 +253,7 @@ export const waitTillGitRepoAvailable = async (repoUrl): Promise<void> => {
       // the ls-remote exist with zero even if repo is empty
       await $`git ls-remote ${repoUrl}`
     } catch (e) {
-      d.warn(`The ${repoUrl} is not yet reachable. Retrying in ${retryOptions.maxTimeout} ms`)
+      d.warn(`The values repository is not yet reachable. Retrying in ${retryOptions.maxTimeout} ms`)
       throw e
     }
   }, retryOptions)


### PR DESCRIPTION
Removed `repoUrl` from `waitTillGitRepoAvailable` error message otherwise it will expose the admin password in the installer logs as showed here:
![image](https://github.com/user-attachments/assets/7f8dcb2e-009c-4e9b-a78b-1864f838c702)
