### PR TITLE
feat: increase Gitea timeout

### DIFF
--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -104,8 +104,8 @@ gitea:
       COOKIE_SECURE: true
       DOMAIN: {{ $giteaDomain }}
       PROVIDER: memory
-      GC_INTERVAL_TIME: 10
-      SESSION_LIFE_TIME: 10
+      GC_INTERVAL_TIME: 25
+      SESSION_LIFE_TIME: 25
     webhook:
       ALLOWED_HOST_LIST: "*"
     server:

--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -104,8 +104,8 @@ gitea:
       COOKIE_SECURE: true
       DOMAIN: {{ $giteaDomain }}
       PROVIDER: memory
-      GC_INTERVAL_TIME: 25
-      SESSION_LIFE_TIME: 25
+      GC_INTERVAL_TIME: 3600
+      SESSION_LIFE_TIME: 3600
     webhook:
       ALLOWED_HOST_LIST: "*"
     server:


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
