### PR TITLE
chore: update console and api to latest release

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,5 +1,5 @@
-api: 3.5.0
-console: 3.4.2
+api: 3.6.0
+console: 3.5.1
 consoleLogin: v3.0.0
 tasks: 3.6.1
 tools: 2.7.0


### PR DESCRIPTION
This PR updates Api to 3.6.0 and console to 3.5.1