### PR TITLE
revert: fix - unique admin password for gitea

### DIFF
--- a/src/common/values.ts
+++ b/src/common/values.ts
@@ -83,7 +83,7 @@ export const getRepo = (values: Record<string, any>): Repo => {
     branch = otomiApiGit?.branch ?? branch
   } else {
     username = 'otomi-admin'
-    password = values?.apps?.gitea?.adminPassword
+    password = values?.apps?.gitea?.adminPassword ?? values?.otomi?.adminPassword
     email = `pipeline@cluster.local`
     const giteaUrl = `gitea-http.gitea.svc.cluster.local:3000`
     const giteaOrg = 'otomi'

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -1821,7 +1821,7 @@ properties:
             $ref: '#/definitions/rawValues'
           adminPassword:
             type: string
-            x-secret: '{{ randAlphaNum 20 }}'
+            x-secret: ''
           postgresqlPassword:
             type: string
             description: This password was generated and cannot be changed without manual intervention.


### PR DESCRIPTION
Reverts linode/apl-core#1910

While we do want this change, it has turned out that the Gitea credentials change and restart during the pipeline run blocks a clean migration. It works on a fresh installation, but will never commit the change back to the values repo in a branch change and therefore cause excessive pipeline run times each time.

We should merge this change again, once we have found a solution for this.