### PR TITLE
fix: workload with validatingwebhookcfg

### DIFF
--- a/charts/team-ns/templates/argocd/argocd-applicationset.yaml
+++ b/charts/team-ns/templates/argocd/argocd-applicationset.yaml
@@ -62,7 +62,15 @@ spec:
             duration: 10s
             factor: 3
           limit: 3
-        syncOptions: []
+        {{- if eq $v.teamId "admin" }} 
+        syncOptions:
+          - RespectIgnoreDifferences=true
+      ignoreDifferences:
+        - group: admissionregistration.k8s.io
+          kind: ValidatingWebhookConfiguration
+          jqPathExpressions:
+          - '.webhooks[]?.clientConfig.caBundle'
+        {{- end }}
       destination:
         server: 'https://kubernetes.default.svc'
         {{- if and ( eq $v.teamId "admin" ) .namespace }} 


### PR DESCRIPTION
Fix to solve argo sync issues when using team-admin to create a workload using a chart with a validatingwebhookconfig resource.
