### PR TITLE
ci: update workflow to support k8s 1.32 and wait for kubeconfig

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -223,16 +223,15 @@ jobs:
             
             sleep 30
           done
-      - name: Save kubectl config with auth token and Get kubectl environment and create docker secret
+      - name: Save kubectl config with auth token
         if: ${{ inputs.install_profile != 'no-apl' }}
         run: |
           # Get the kubeconfig from linode-cli
           echo -n "Waiting for kubeconfig"
-          KUBECONFIG_RETRIEVED=0
-          while [ $KUBECONFIG_RETRIEVED = 0 ]; do
+          while :; do
             echo -n "."
+            linode-cli get-kubeconfig --label "${{ env.LINODE_CLUSTER_NAME }}" 2> /dev/null && break
             sleep 10
-            linode-cli get-kubeconfig --label "env.LINODE_CLUSTER_NAME" 2> /dev/null && KUBECONFIG_RETRIEVED=1
           done
           echo LINODE_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
       - name: Create image pull secret on test cluster

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -227,10 +227,10 @@ jobs:
         if: ${{ inputs.install_profile != 'no-apl' }}
         run: |
           # Get the kubeconfig from linode-cli
-          echo -n "Waiting for kubeconfig"
+          echo "Waiting for kubeconfig..."
           while :; do
-            echo -n "."
             linode-cli get-kubeconfig --label "${{ env.LINODE_CLUSTER_NAME }}" 2> /dev/null && break
+            echo "still waiting..."
             sleep 10
           done
           echo LINODE_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -226,7 +226,6 @@ jobs:
       - name: Save kubectl config with auth token
         if: ${{ inputs.install_profile != 'no-apl' }}
         run: |
-          # Get the kubeconfig from linode-cli
           echo "Waiting for kubeconfig..."
           while :; do
             linode-cli get-kubeconfig --label "${{ env.LINODE_CLUSTER_NAME }}" 2> /dev/null && break

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,10 +32,10 @@ on:
         description: 'Kubernetes version'
         type: choice
         options:
-          - "['1.29']"
           - "['1.30']"
           - "['1.31']"
-        default: "['1.31']"
+          - "['1.32']"
+        default: "['1.32']"
       install_profile:
         description: APL installation profile
         default: minimal-with-team

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -227,20 +227,13 @@ jobs:
         if: ${{ inputs.install_profile != 'no-apl' }}
         run: |
           # Get the kubeconfig from linode-cli
-          kubeconfig=$(linode-cli lke kubeconfig-view ${{ env.LINODE_CLUSTER_ID }} --text | sed 1d | base64 --decode)
-
-          # Save the kubeconfig to a file
-          kubeconfigDir="$HOME/.kube"
-          kubeconfigPath="$HOME/.kube/config"
-          mkdir -p "$kubeconfigDir"  # Create the directory if it doesn't exist
-          echo "$kubeconfig" > "$kubeconfigPath"
-          echo "Kubeconfig saved to $kubeconfigPath"
-              
-          # Set the kubectl context to use the new kubeconfig
-          export KUBECONFIG="$kubeconfigPath"
-          contextName=$(kubectl config get-contexts -o name | head -n 1)
-          kubectl config use-context "$contextName"
-          echo "Kubectl context set to linode"
+          echo -n "Waiting for kubeconfig"
+          KUBECONFIG_RETRIEVED=0
+          while [ $KUBECONFIG_RETRIEVED = 0 ]; do
+            echo -n "."
+            sleep 10
+            linode-cli get-kubeconfig --label "env.LINODE_CLUSTER_NAME" 2> /dev/null && KUBECONFIG_RETRIEVED=1
+          done
           echo LINODE_CLUSTER_CONTEXT=`kubectl config current-context` >> $GITHUB_ENV
       - name: Create image pull secret on test cluster
         if: ${{ inputs.install_profile != 'no-apl' }}


### PR DESCRIPTION
This PR updates the list of versions to the ones currently shown as supported by the Linode API, including 1.32 and removing 1.29. Also a change was made to wait until the Kubeconfig can be retrieved, as relying on all nodes being up and running turned out not to be sufficient.