### PR TITLE
fix: removed git error which can expose credentials

### DIFF
--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -57,7 +57,6 @@ const commitAndPush = async (values: Record<string, any>, branch: string): Promi
         await $`git push -u origin ${branch}`
       } catch (e) {
         d.warn(`The values repository is not yet reachable. Retrying.`)
-        throw e
       }
     },
     {


### PR DESCRIPTION
This fix addresses a possible exposure of the otomi-admin credentials in case the `commitAndPush ` fails as showed here:
![image](https://github.com/user-attachments/assets/97a5ba02-6cfb-45c4-aa0f-04e1d0a63e78)

