### PR TITLE
ci: update chart index and improve checks

### DIFF
--- a/chart/chart-index/Chart.yaml
+++ b/chart/chart-index/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     version: 0.23.0
     repository: https://cloudnative-pg.github.io/charts
   - name: external-dns
-    version: 6.20.4
+    version: 8.3.9
     repository: https://charts.bitnami.com/bitnami
   - name: falco
     version: 3.8.5
@@ -30,10 +30,10 @@ dependencies:
     version: 1.16.2
     repository: https://helm.goharbor.io
   - name: ingress-nginx
-    version: 4.6.1
+    version: 4.11.2
     repository: https://kubernetes.github.io/ingress-nginx
   - name: jaeger-operator
-    version: 2.57.0
+    version: 2.46.0
     repository: https://jaegertracing.github.io/helm-charts
   - name: kiali-operator
     version: 1.86.1
@@ -42,7 +42,7 @@ dependencies:
     version: 0.1.0
     repository: https://knative.github.io/operator
   - name: kube-prometheus-stack
-    version: 46.4.1
+    version: 65.2.0
     repository: https://prometheus-community.github.io/helm-charts
   - name: kured
     version: 4.6.0
@@ -61,7 +61,7 @@ dependencies:
     version: 11.10.13
     repository: https://charts.bitnami.com/bitnami
   - name: oauth2-proxy
-    version: 3.7.4
+    version: 7.7.24
     repository: https://charts.bitnami.com/bitnami
   - name: opentelemetry-operator
     alias: otel-operator

--- a/chart/chart-index/Chart.yaml
+++ b/chart/chart-index/Chart.yaml
@@ -83,6 +83,7 @@ dependencies:
     version: 2.17.1
     repository: https://bitnami-labs.github.io/sealed-secrets/
   - name: tekton-pipeline
+    alias: tekton-pipelines
     version: 1.0.2
     repository: https://cdfoundation.github.io/tekton-helm-chart/
   - name: tempo-distributed

--- a/ci/src/update-helm-chart-deps.mjs
+++ b/ci/src/update-helm-chart-deps.mjs
@@ -188,13 +188,13 @@ async function main() {
     }
 
     console.log('Dependency updates complete.')
-    if (dependencyErrors) {
+    if (Object.keys(dependencyErrors).length > 0) {
       console.log('Summary of errors encountered during the update:')
       Object.entries(dependencyErrors).forEach(([key, value]) => {
         console.log(`${key}:`, value)
       })
     }
-    if (fixedChartVersions && !ciPushtoBranch) {
+    if (Object.keys(fixedChartVersions).length > 0 && !ciPushtoBranch) {
       console.log('Writing mismatching versions to chart index.')
       for (const dependency of chart.dependencies) {
         const fixedVersion = fixedChartVersions[dependency.name]

--- a/ci/src/update-helm-chart-deps.mjs
+++ b/ci/src/update-helm-chart-deps.mjs
@@ -67,6 +67,20 @@ async function main() {
         continue
       }
 
+      console.log(`Pre-check for dependency ${dependency.name}`)
+      try {
+        const dependencyFileName = `${chartsDir}/${dependency.alias || dependency.name}/Chart.yaml`
+        const dependencyFile = await fs.readFile(dependencyFileName, 'utf8')
+        const dependencyChart = yaml.load(dependencyFile)
+        if (dependencyChart.version !== currentDependencyVersion) {
+          console.error(`Skipping update, indexed version of dependency ${dependency.name} is not consistent with chart version.`)
+          continue
+        }
+      } catch (error) {
+        console.error(`Error checking dependency ${dependency.name}:`, error)
+        continue
+      }
+
       console.log(`Checking updates for dependency: ${dependency.name}`)
       try {
         // Add the Helm repository (idempotent)

--- a/ci/src/update-helm-chart-deps.mjs
+++ b/ci/src/update-helm-chart-deps.mjs
@@ -124,7 +124,7 @@ async function main() {
         const existingBranch = await checkBranchCmd
         if (existingBranch.stdout !== '') {
           console.log(
-            `Skipping updates for dependency: ${dependency.name}: the remote branch ${branchName} already exists`,
+            `Skipping updates for dependency: ${dependency.name}: the feature branch ${branchName} already exists`,
           )
           continue
         }
@@ -136,7 +136,7 @@ async function main() {
 
         const commitMessage = `chore(chart-deps): update ${dependency.name} to version ${latestVersion}`
         if (ciCreateFeatureBranch) {
-          await $`git checkout -c core.hooksPath=/dev/null -b ${branchName}`
+          await $`git -c core.hooksPath=/dev/null checkout -b ${branchName}`
         }
 
         // Write the updated Chart.yaml file
@@ -178,7 +178,7 @@ async function main() {
         dependency.version = currentDependencyVersion
         if (ciCreateFeatureBranch) {
           // Reset to the main branch for the next dependency
-          await $`git checkout -c core.hooksPath=/dev/null ${baseBranch}`
+          await $`git -c core.hooksPath=/dev/null checkout ${baseBranch}`
           await $`git reset --hard ${ciPushtoBranch ? 'origin/' : ''}${baseBranch}`
         }
       }


### PR DESCRIPTION
This PR includes the following changes to the chart update script:
* It checks if the index version corresponds with the chart's version. If not, the update is skipped. When running locally, `CI_GIT_LOCAL_BRANCH_ONLY` can be set to `true` for preparing a fix. Resulting changes should be submitted to a separate PR.
* Any errors leading to skipping a chart are summarized at the end, as they tend to disappear in the log output.
* Some improvements to running the script locally. For example, the checkout hooks are skipped.

Also, two inaccuracies in the chart index were found and fixed, including the version mismatches above and a missing alias for the `tekton-pipeline` chart.