### PR TITLE
chore: versions

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: APL-579
+api: 3.6.2
 console: 3.5.1
 consoleLogin: v3.5.0
 tasks: 3.6.1

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 3.6.1
+api: APL-579
 console: 3.5.1
 consoleLogin: v3.5.0
 tasks: 3.6.1


### PR DESCRIPTION
`apl-api v3.6.2` is released.