### PR TITLE
chore: tasks version to 3.7.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,5 +1,5 @@
 api: 3.6.2
 console: 3.5.1
 consoleLogin: v3.5.0
-tasks: 3.6.1
+tasks: 3.7.0
 tools: 2.8.7


### PR DESCRIPTION
This PR updates the apl-tasks version to the newest release