### PR TITLE
ci: update manifest kind in fixtures

### DIFF
--- a/tests/fixtures/env/apps/alertmanager.yaml
+++ b/tests/fixtures/env/apps/alertmanager.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: alertmanager
     labels: {}

--- a/tests/fixtures/env/apps/argocd.yaml
+++ b/tests/fixtures/env/apps/argocd.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: argocd
     labels: {}

--- a/tests/fixtures/env/apps/cert-manager.yaml
+++ b/tests/fixtures/env/apps/cert-manager.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: cert-manager
     labels: {}

--- a/tests/fixtures/env/apps/cnpg.yaml
+++ b/tests/fixtures/env/apps/cnpg.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: cnpg
     labels: {}

--- a/tests/fixtures/env/apps/drone.yaml
+++ b/tests/fixtures/env/apps/drone.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: drone
     labels: {}

--- a/tests/fixtures/env/apps/falco.yaml
+++ b/tests/fixtures/env/apps/falco.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: falco
     labels: {}

--- a/tests/fixtures/env/apps/gitea.yaml
+++ b/tests/fixtures/env/apps/gitea.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: gitea
     labels: {}

--- a/tests/fixtures/env/apps/grafana.yaml
+++ b/tests/fixtures/env/apps/grafana.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: grafana
     labels: {}

--- a/tests/fixtures/env/apps/harbor.yaml
+++ b/tests/fixtures/env/apps/harbor.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: harbor
     labels: {}

--- a/tests/fixtures/env/apps/httpbin.yaml
+++ b/tests/fixtures/env/apps/httpbin.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: httpbin
     labels: {}

--- a/tests/fixtures/env/apps/ingress-nginx-net-a.yaml
+++ b/tests/fixtures/env/apps/ingress-nginx-net-a.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: ingress-nginx-net-a
     labels: {}

--- a/tests/fixtures/env/apps/ingress-nginx-platform.yaml
+++ b/tests/fixtures/env/apps/ingress-nginx-platform.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: ingress-nginx-platform
     labels: {}

--- a/tests/fixtures/env/apps/istio.yaml
+++ b/tests/fixtures/env/apps/istio.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: istio
     labels: {}

--- a/tests/fixtures/env/apps/jaeger.yaml
+++ b/tests/fixtures/env/apps/jaeger.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: jaeger
     labels: {}

--- a/tests/fixtures/env/apps/keycloak.yaml
+++ b/tests/fixtures/env/apps/keycloak.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: keycloak
     labels: {}

--- a/tests/fixtures/env/apps/kiali.yaml
+++ b/tests/fixtures/env/apps/kiali.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: kiali
     labels: {}

--- a/tests/fixtures/env/apps/knative.yaml
+++ b/tests/fixtures/env/apps/knative.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: knative
     labels: {}

--- a/tests/fixtures/env/apps/kured.yaml
+++ b/tests/fixtures/env/apps/kured.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: kured
     labels: {}

--- a/tests/fixtures/env/apps/kyverno.yaml
+++ b/tests/fixtures/env/apps/kyverno.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: kyverno
     labels: {}

--- a/tests/fixtures/env/apps/loki.yaml
+++ b/tests/fixtures/env/apps/loki.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: loki
     labels: {}

--- a/tests/fixtures/env/apps/metrics-server.yaml
+++ b/tests/fixtures/env/apps/metrics-server.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: metrics-server
     labels: {}

--- a/tests/fixtures/env/apps/minio.yaml
+++ b/tests/fixtures/env/apps/minio.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: minio
     labels: {}

--- a/tests/fixtures/env/apps/oauth2-proxy-redis.yaml
+++ b/tests/fixtures/env/apps/oauth2-proxy-redis.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: oauth2-proxy-redis
     labels: {}

--- a/tests/fixtures/env/apps/oauth2-proxy.yaml
+++ b/tests/fixtures/env/apps/oauth2-proxy.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: oauth2-proxy
     labels: {}

--- a/tests/fixtures/env/apps/opencost.yaml
+++ b/tests/fixtures/env/apps/opencost.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: opencost
     labels: {}

--- a/tests/fixtures/env/apps/otel.yaml
+++ b/tests/fixtures/env/apps/otel.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: otel
     labels: {}

--- a/tests/fixtures/env/apps/otomi-api.yaml
+++ b/tests/fixtures/env/apps/otomi-api.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: otomi-api
     labels: {}

--- a/tests/fixtures/env/apps/prometheus-blackbox-exporter.yaml
+++ b/tests/fixtures/env/apps/prometheus-blackbox-exporter.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: prometheus-blackbox-exporter
     labels: {}

--- a/tests/fixtures/env/apps/prometheus.yaml
+++ b/tests/fixtures/env/apps/prometheus.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: prometheus
     labels: {}

--- a/tests/fixtures/env/apps/rabbitmq.yaml
+++ b/tests/fixtures/env/apps/rabbitmq.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: rabbitmq
     labels: {}

--- a/tests/fixtures/env/apps/redis-shared.yaml
+++ b/tests/fixtures/env/apps/redis-shared.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: redis-shared
     labels: {}

--- a/tests/fixtures/env/apps/sealed-secrets.yaml
+++ b/tests/fixtures/env/apps/sealed-secrets.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: sealed-secrets
     labels: {}

--- a/tests/fixtures/env/apps/secrets.cert-manager.yaml
+++ b/tests/fixtures/env/apps/secrets.cert-manager.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     customRootCA: |
         -----BEGIN CERTIFICATE-----

--- a/tests/fixtures/env/apps/secrets.drone.yaml
+++ b/tests/fixtures/env/apps/secrets.drone.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     sharedSecret: somesecretvalue
     sourceControl:

--- a/tests/fixtures/env/apps/secrets.gitea.yaml
+++ b/tests/fixtures/env/apps/secrets.gitea.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     adminPassword: giteaAdminPassword
     postgresqlPassword: postgresqlPassword

--- a/tests/fixtures/env/apps/secrets.grafana.yaml
+++ b/tests/fixtures/env/apps/secrets.grafana.yaml
@@ -1,3 +1,3 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     adminPassword: somesecretvalue

--- a/tests/fixtures/env/apps/secrets.harbor.yaml
+++ b/tests/fixtures/env/apps/secrets.harbor.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     adminPassword: harborsomesecretvalue
     core:

--- a/tests/fixtures/env/apps/secrets.keycloak.yaml
+++ b/tests/fixtures/env/apps/secrets.keycloak.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     idp:
         clientSecret: somsecretvalue

--- a/tests/fixtures/env/apps/secrets.loki.yaml
+++ b/tests/fixtures/env/apps/secrets.loki.yaml
@@ -1,3 +1,3 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     adminPassword: somesecretvalue

--- a/tests/fixtures/env/apps/secrets.oauth2-proxy-redis.yaml
+++ b/tests/fixtures/env/apps/secrets.oauth2-proxy-redis.yaml
@@ -1,3 +1,3 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     password: gkhugxJsPjhbCybH

--- a/tests/fixtures/env/apps/secrets.oauth2-proxy.yaml
+++ b/tests/fixtures/env/apps/secrets.oauth2-proxy.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     config:
         cookieSecret: gkhugxJsPjhbCybH

--- a/tests/fixtures/env/apps/secrets.otomi-api.yaml
+++ b/tests/fixtures/env/apps/secrets.otomi-api.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     git:
         password: somesecretvalue

--- a/tests/fixtures/env/apps/secrets.prometheus.yaml
+++ b/tests/fixtures/env/apps/secrets.prometheus.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 spec:
     remoteWrite:
         rwConfig:

--- a/tests/fixtures/env/apps/tekton.yaml
+++ b/tests/fixtures/env/apps/tekton.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: tekton
     labels: {}

--- a/tests/fixtures/env/apps/tempo.yaml
+++ b/tests/fixtures/env/apps/tempo.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: tempo
     labels: {}

--- a/tests/fixtures/env/apps/thanos.yaml
+++ b/tests/fixtures/env/apps/thanos.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: thanos
     labels: {}

--- a/tests/fixtures/env/apps/trivy.yaml
+++ b/tests/fixtures/env/apps/trivy.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: trivy
     labels: {}

--- a/tests/fixtures/env/apps/velero.yaml
+++ b/tests/fixtures/env/apps/velero.yaml
@@ -1,4 +1,4 @@
-kind: AplCoreApp
+kind: AplApp
 metadata:
     name: velero
     labels: {}

--- a/tests/fixtures/env/settings/alerts.yaml
+++ b/tests/fixtures/env/settings/alerts.yaml
@@ -1,4 +1,4 @@
-kind: AplAlerts
+kind: AplAlertSet
 metadata:
     name: alerts
     labels: {}

--- a/tests/fixtures/env/settings/otomi.yaml
+++ b/tests/fixtures/env/settings/otomi.yaml
@@ -1,4 +1,4 @@
-kind: AplCapabilities
+kind: AplCapabilitySet
 metadata:
     name: otomi
     labels: {}

--- a/tests/fixtures/env/settings/platformBackups.yaml
+++ b/tests/fixtures/env/settings/platformBackups.yaml
@@ -1,4 +1,4 @@
-kind: AplBackups
+kind: AplBackupCollection
 metadata:
     name: platformBackups
     labels: {}

--- a/tests/fixtures/env/settings/secrets.alerts.yaml
+++ b/tests/fixtures/env/settings/secrets.alerts.yaml
@@ -1,4 +1,4 @@
-kind: AplAlerts
+kind: AplAlertSet
 spec:
     email:
         critical: admins@yourdoma.in

--- a/tests/fixtures/env/settings/secrets.otomi.yaml
+++ b/tests/fixtures/env/settings/secrets.otomi.yaml
@@ -1,4 +1,4 @@
-kind: AplCapabilities
+kind: AplCapabilitySet
 spec:
     adminPassword: bladibla
     globalPullSecret:

--- a/tests/fixtures/env/settings/secrets.platformBackups.yaml
+++ b/tests/fixtures/env/settings/secrets.platformBackups.yaml
@@ -1,4 +1,4 @@
-kind: AplBackups
+kind: AplBackupCollection
 spec:
     persistentVolumes:
         linodeApiToken: justanapitokenhere

--- a/tests/fixtures/env/settings/versions.yaml
+++ b/tests/fixtures/env/settings/versions.yaml
@@ -1,4 +1,4 @@
-kind: AplVersions
+kind: AplVersion
 metadata:
     name: versions
     labels: {}

--- a/tests/fixtures/env/teams/admin/apps.yaml
+++ b/tests/fixtures/env/teams/admin/apps.yaml
@@ -1,4 +1,4 @@
-kind: AplTeamTools
+kind: AplTeamTool
 metadata:
     name: admin
     labels:

--- a/tests/fixtures/env/teams/admin/policies.yaml
+++ b/tests/fixtures/env/teams/admin/policies.yaml
@@ -97,3 +97,15 @@ spec:
             - projected
             - secret
         severity: medium
+    require-liveness-probe:
+        action: Audit
+        severity: medium
+    require-non-root-groups:
+        action: Audit
+        severity: medium
+    require-readiness-probe:
+        action: Audit
+        severity: medium
+    require-startup-probe:
+        action: Audit
+        severity: medium

--- a/tests/fixtures/env/teams/admin/secrets.settings.yaml
+++ b/tests/fixtures/env/teams/admin/secrets.settings.yaml
@@ -1,3 +1,3 @@
-kind: AplTeamSettings
+kind: AplTeamSettingSet
 spec:
     password: YTrnkdUsKPcGATfg

--- a/tests/fixtures/env/teams/admin/settings.yaml
+++ b/tests/fixtures/env/teams/admin/settings.yaml
@@ -1,4 +1,4 @@
-kind: AplTeamSettings
+kind: AplTeamSettingSet
 metadata:
     name: admin
     labels:

--- a/tests/fixtures/env/teams/demo/apps.yaml
+++ b/tests/fixtures/env/teams/demo/apps.yaml
@@ -1,4 +1,4 @@
-kind: AplTeamTools
+kind: AplTeamTool
 metadata:
     name: demo
     labels:

--- a/tests/fixtures/env/teams/demo/policies.yaml
+++ b/tests/fixtures/env/teams/demo/policies.yaml
@@ -97,3 +97,15 @@ spec:
             - projected
             - secret
         severity: medium
+    require-liveness-probe:
+        action: Audit
+        severity: medium
+    require-non-root-groups:
+        action: Audit
+        severity: medium
+    require-readiness-probe:
+        action: Audit
+        severity: medium
+    require-startup-probe:
+        action: Audit
+        severity: medium

--- a/tests/fixtures/env/teams/demo/settings.yaml
+++ b/tests/fixtures/env/teams/demo/settings.yaml
@@ -1,4 +1,4 @@
-kind: AplTeamSettings
+kind: AplTeamSettingSet
 metadata:
     name: demo
     labels:

--- a/tests/fixtures/env/teams/dev/apps.yaml
+++ b/tests/fixtures/env/teams/dev/apps.yaml
@@ -1,4 +1,4 @@
-kind: AplTeamTools
+kind: AplTeamTool
 metadata:
     name: dev
     labels:

--- a/tests/fixtures/env/teams/dev/policies.yaml
+++ b/tests/fixtures/env/teams/dev/policies.yaml
@@ -97,3 +97,15 @@ spec:
             - projected
             - secret
         severity: medium
+    require-liveness-probe:
+        action: Audit
+        severity: medium
+    require-non-root-groups:
+        action: Audit
+        severity: medium
+    require-readiness-probe:
+        action: Audit
+        severity: medium
+    require-startup-probe:
+        action: Audit
+        severity: medium

--- a/tests/fixtures/env/teams/dev/settings.yaml
+++ b/tests/fixtures/env/teams/dev/settings.yaml
@@ -1,4 +1,4 @@
-kind: AplTeamSettings
+kind: AplTeamSettingSet
 metadata:
     name: dev
     labels:


### PR DESCRIPTION
This PR updates the fixtures to use the `kind` value for manifests that we defined. They were changed after the fixtures had been generated.
Currently this had no effect, but as of APL-551 the API will start checking if the `kind` matches according to the specified file path and skip invalid files.