### PR TITLE
chore: set api version 4.1.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: 4.1.0
+api: 4.1.1
 console: 4.0.1
 consoleLogin: v3.5.0
 tasks: 3.8.0


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
