### PR TITLE
fix: pull before pushing to gitea in commitAndPush func

### DIFF
--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -55,6 +55,7 @@ const commitAndPush = async (values: Record<string, any>, branch: string): Promi
     async () => {
       try {
         cd(env.ENV_DIR)
+        await $`git pull --rebase origin ${branch}`
         await $`git push -u origin ${branch}`
       } catch (e) {
         d.warn(`The values repository is not yet reachable.`)


### PR DESCRIPTION
## Checklist

- [ ] Architecture Design Records have been added as `adr/*.md` and appended to list in `adr/_index.md`, if applicable.
- [ ] The `values-schema.yaml` file and `test/**` fixtures have been updated to reflect code changes, if applicable.
- [ ] The OpenApi Schema from redkubes/otomi-api project is compatible with definitions from `values-schema.yaml` file, if applicable.
- [ ] Helm releases are meeting otomi's baseline security policies, if applicable.
- [ ] Helm chart and helmfile changes are tested against upgrade scenario, if applicable.
