### PR TITLE
ci: added release candidate pipelines

### DIFF
--- a/.github/workflows/create_rc.yml
+++ b/.github/workflows/create_rc.yml
@@ -1,5 +1,5 @@
 name: Create Release Candidate.
-run-name: Create Release Candidate from commit ${{ github.event.inputs.rc_commit_sha }}
+run-name: Create Release Candidate from ${{ github.event.inputs.rc_commit_sha || 'main' }}
 
 on:
   workflow_dispatch:
@@ -31,20 +31,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine commit from where to create the RC
-        id: determine_commit
-        run: |
-          if [ "${{ github.event.inputs.rc_commit_sha }}" == "" ]; then
-            echo "No commit sha provided, using the latest commit on main"
-            echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          else
-            echo "Using provided commit sha: ${{ github.event.inputs.rc_commit_sha }}"
-            echo "commit_sha=${{ github.event.inputs.rc_commit_sha }}" >> $GITHUB_ENV
-          fi
-
       #TODO: Use the same user id on the container as in the runner to avoid the "dubious ownership" error
       - name: Mark repository as safe for Git
         run: git config --global --add safe.directory /__w/apl-core/apl-core
+
+      - name: Determine commit from where to create the RC
+        id: determine_commit
+        run: |
+          if [ -n "${{ github.event.inputs.rc_commit_sha }}" ]; then
+            commit_sha="${{ github.event.inputs.rc_commit_sha }}"
+            echo "Using provided commit sha: $commit_sha"
+            echo "commit_sha=$commit_sha" >> $GITHUB_ENV
+          else
+            commit_sha=$(git rev-parse HEAD)
+            echo "No commit sha provided, using the latest commit on main: $commit_sha"
+            echo "commit_sha=$commit_sha" >> $GITHUB_ENV
+          fi
+
+      - name: Install standard-version
+        run: |
+          npm install standard-version
 
       - name: Create release candidate tag & branch
         id: create_release
@@ -52,13 +58,15 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMIT_SHA: ${{ env.commit_sha }}
+          BOT_EMAIL: ${{ vars.BOT_EMAIL }}
+          BOT_USERNAME: ${{ vars.BOT_USERNAME }}
         run: |
           ci/scripts/create_rc.sh
 
       - name: Prepare chart
         env:
-          BOT_EMAIL: ${{ secrets.BOT_EMAIL }}
-          BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
+          BOT_EMAIL: ${{ vars.BOT_EMAIL }}
+          BOT_USERNAME: ${{ vars.BOT_USERNAME }}
         id: prepare_chart
         run: |
           ci/scripts/prepare_chart_for_release.sh
@@ -66,12 +74,21 @@ jobs:
       - name: Dry Run Outputs
         if: ${{ github.event.inputs.dry_run == 'true'}}
         run: |
-          echo -e "This Pipeline was executed in dry run mode so it will not publish the helm chart.\nBelow are some useful data to check:"
-          echo "Release candidate branch: ${{ github.ref }}"
+          echo "This Pipeline was executed in dry run mode so it will not publish the helm chart."
+          echo "Below are some useful data to check:"
+          echo "Release candidate branch: $(git rev-parse --abbrev-ref HEAD)"
+          echo "-*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*"
           echo "Contents of: chart/apl/Chart.yaml"
           cat chart/apl/Chart.yaml
+          echo "-*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*"
           echo "Contents of: package.json"
           cat package.json
+          echo "-*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*"
+          echo "Latest 5 commits on the release candidate branch"
+          git log -n 5 --pretty=format:"%h %s" --abbrev-commit
+          echo "-*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*--*-*"
+          echo "Commits behind main branch VS Commits ahead of main branch"
+          git rev-list --left-right --count origin/main...HEAD
 
       - name: Create and publish otomi chart release
         if: ${{ github.event.inputs.dry_run == 'false' }}

--- a/.github/workflows/create_rc.yml
+++ b/.github/workflows/create_rc.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       dry_run:
-        description: 'If you want to run the workflow without making any changes'
+        description: 'Dry Run: If true, the pipeline will not publish the helm chart.'
         required: true
         default: 'true'
         type: choice
@@ -20,6 +20,9 @@ on:
 jobs:
   create_patch_release:
     runs-on: ubuntu-latest
+    container:
+      image: linode/apl-tools:v2.8.7
+      options: --user 0 # See https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
     outputs:
       rc_branch: ${{ steps.create_release.outputs.rc_branch }}
     steps:
@@ -28,22 +31,22 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install standard-version
-        run: |
-          npm install standard-version
-
       - name: Determine commit from where to create the RC
         id: determine_commit
         run: |
           if [ "${{ github.event.inputs.rc_commit_sha }}" == "" ]; then
-            echo "No commit sha provided, using the latest commit"
+            echo "No commit sha provided, using the latest commit on main"
             echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
           else
-            echo "Using provided commit sha"
+            echo "Using provided commit sha: ${{ github.event.inputs.rc_commit_sha }}"
             echo "commit_sha=${{ github.event.inputs.rc_commit_sha }}" >> $GITHUB_ENV
           fi
 
-      - name: Create release candidate tag
+      #TODO: Use the same user id on the container as in the runner to avoid the "dubious ownership" error
+      - name: Mark repository as safe for Git
+        run: git config --global --add safe.directory /__w/apl-core/apl-core
+
+      - name: Create release candidate tag & branch
         id: create_release
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
@@ -51,21 +54,6 @@ jobs:
           COMMIT_SHA: ${{ env.commit_sha }}
         run: |
           ci/scripts/create_rc.sh
-          echo "rc_branch=$(cat rc_branch_name.txt)" >> $GITHUB_OUTPUT
-
-  chart-release:
-    needs: create_patch_release
-    if: always() && contains(needs.create_patch_release.result, 'success') && !github.event.act
-    runs-on: ubuntu-22.04
-    container:
-      image: linode/apl-tools:v2.8.2
-      options: --user 0 # See https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.create_patch_release.outputs.rc_branch }}
 
       - name: Prepare chart
         env:
@@ -75,19 +63,16 @@ jobs:
         run: |
           ci/scripts/prepare_chart_for_release.sh
 
-      #TODO: Use the same user id on the container as in the runner to avoid the "dubious ownership" error
-      - name: Mark repository as safe for Git
-        run: git config --global --add safe.directory /__w/apl-core/apl-core
-
       - name: Dry Run Outputs
         if: ${{ github.event.inputs.dry_run == 'true'}}
         run: |
           echo -e "This Pipeline was executed in dry run mode so it will not publish the helm chart.\nBelow are some useful data to check:"
+          echo "Release candidate branch: ${{ github.ref }}"
           echo "Contents of: chart/apl/Chart.yaml"
           cat chart/apl/Chart.yaml
           echo "Contents of: package.json"
           cat package.json
-          echo
+
       - name: Create and publish otomi chart release
         if: ${{ github.event.inputs.dry_run == 'false' }}
         id: chart_release

--- a/.github/workflows/create_rc.yml
+++ b/.github/workflows/create_rc.yml
@@ -19,10 +19,7 @@ on:
 
 jobs:
   create_patch_release:
-    runs-on: ubuntu-latest
-    container:
-      image: linode/apl-tools:v2.8.7
-      options: --user 0 # See https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
+    runs-on: ubuntu-22.04
     outputs:
       rc_branch: ${{ steps.create_release.outputs.rc_branch }}
     steps:
@@ -30,10 +27,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      #TODO: Use the same user id on the container as in the runner to avoid the "dubious ownership" error
-      - name: Mark repository as safe for Git
-        run: git config --global --add safe.directory /__w/apl-core/apl-core
 
       - name: Determine commit from where to create the RC
         id: determine_commit
@@ -48,7 +41,7 @@ jobs:
             echo "commit_sha=$commit_sha" >> $GITHUB_ENV
           fi
 
-      - name: Install standard-version
+      - name: Install dependencies
         run: |
           npm install standard-version
 

--- a/.github/workflows/create_rc.yml
+++ b/.github/workflows/create_rc.yml
@@ -1,0 +1,150 @@
+name: Create Release Candidate.
+run-name: Create Release Candidate from commit ${{ github.event.inputs.rc_commit_sha }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_commit_sha:
+        description: 'Commit from which to create the release candidate. If not provided, the latest commit on main will be used'
+        required: false
+        type: string
+      dry_run:
+        description: 'If you want to run the workflow without making any changes'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - true
+          - false
+
+jobs:
+  create_patch_release:
+    runs-on: ubuntu-latest
+    outputs:
+      rc_branch: ${{ steps.create_release.outputs.rc_branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install standard-version
+        run: |
+          npm install standard-version
+
+      - name: Determine commit from where to create the RC
+        id: determine_commit
+        run: |
+          if [ "${{ github.event.inputs.rc_commit_sha }}" == "" ]; then
+            echo "No commit sha provided, using the latest commit"
+            echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          else
+            echo "Using provided commit sha"
+            echo "commit_sha=${{ github.event.inputs.rc_commit_sha }}" >> $GITHUB_ENV
+          fi
+
+      - name: Create release candidate tag
+        id: create_release
+        run: |
+
+          git config --global user.email "rc_githubactions@github.com"
+          git config --global user.name "Release Candidate GitHub Action "
+
+          git reset --hard ${{ env.commit_sha }}
+
+          # Use standard-version to determine the next version
+          npm run release -- --skip.commit --skip.tag --skip.changelog
+          new_version=$(jq -r '.version' package.json)
+          branch_name=rc/v${new_version%.*}
+          echo "rc_branch=$branch_name" >> $GITHUB_OUTPUT
+          release_branch_name=${branch_name//rc/release}
+
+          git reset --hard ${{ env.commit_sha }}
+
+          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+            echo "Dry run enabled. The following commands would be executed:"
+            echo "git checkout -b $branch_name"
+            echo "npm run release -- --prerelease rc --skip.changelog --dry-run"
+            npm run release -- --prerelease rc --skip.changelog --dry-run
+            echo "git push -u origin $branch_name --follow-tags"
+          else
+            
+            git checkout -b $branch_name
+            npm run release -- --prerelease rc --skip.changelog
+            git push -u origin $branch_name --follow-tags
+          fi
+
+      - name: Create Github Release
+        id: create_github_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag=$(jq -r '.version' package.json)
+          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
+            echo "Dry run enabled. The following commands would be executed otherwise:"
+            echo gh release create "$tag" --title="Release Candidate: $tag" --notes="Automated release for $tag" --latest=false -p
+          else
+            gh release create "$tag" --title="Release Candidate: $tag" --notes="Automated release for $tag" --latest=false -p
+          fi
+
+  chart-release:
+    needs: create_patch_release
+    if: always() && contains(needs.create_patch_release.result, 'success') && !github.event.act
+    runs-on: ubuntu-22.04
+    container:
+      image: linode/apl-tools:v2.8.2
+      options: --user 0 # See https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.create_patch_release.outputs.rc_branch }}
+
+      - name: Prepare chart
+        id: prepare_chart
+        run: |
+          # Retrieve the app version from package.json
+          app_version=$(jq -r '.version' package.json)
+
+          # Update Chart.yaml and values.yaml with the new app version
+          sed -i "s/0.0.0-chart-version/$app_version/g" chart/apl/Chart.yaml
+          sed -i "s/APP_VERSION_PLACEHOLDER/v$app_version/g" chart/apl/Chart.yaml
+
+          echo "Chart and values files updated successfully with version $app_version"
+
+          # Copy readme from repo into the charts and add tpl/chart-values.md
+          cp README.md chart/apl/
+          printf "\n\n" >>chart/apl/README.md
+          cat tpl/chart-values.md >>chart/apl/README.md
+
+          # Generate schema
+          npx js-yaml values-schema.yaml > chart/apl/values.schema.json
+
+          # Set the global id for git as it seems needed by the next step when a custom image is used
+          git config --global user.email ${{ env.BOT_EMAIL }}
+          git config --global user.name ${{ env.BOT_USERNAME }}
+
+      #TODO: Use the same user id on the container as in the runner to avoid the "dubious ownership" error
+      - name: Mark repository as safe for Git
+        run: git config --global --add safe.directory /__w/apl-core/apl-core
+
+      - name: Dry Run Outputs
+        if: ${{ github.event.inputs.dry_run }}
+        run: |
+          echo -e "This Pipeline was executed in dry run mode so it will not publish the helm chart.\nBelow are some useful data to check:"
+          echo "Contents of: chart/apl/Chart.yaml"
+          cat chart/apl/Chart.yaml
+          echo "Contents of: package.json"
+          cat package.json
+          echo
+      - name: Create and publish otomi chart release
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        id: chart_release
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: chart
+          skip_existing: true
+          mark_as_latest: false
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/create_rc.yml
+++ b/.github/workflows/create_rc.yml
@@ -130,7 +130,7 @@ jobs:
         run: git config --global --add safe.directory /__w/apl-core/apl-core
 
       - name: Dry Run Outputs
-        if: ${{ github.event.inputs.dry_run }}
+        if: ${{ github.event.inputs.dry_run == 'true'}}
         run: |
           echo -e "This Pipeline was executed in dry run mode so it will not publish the helm chart.\nBelow are some useful data to check:"
           echo "Contents of: chart/apl/Chart.yaml"

--- a/.github/workflows/create_rc.yml
+++ b/.github/workflows/create_rc.yml
@@ -73,26 +73,7 @@ jobs:
           BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
         id: prepare_chart
         run: |
-          # Retrieve the app version from package.json
-          app_version=$(jq -r '.version' package.json)
-
-          # Update Chart.yaml and values.yaml with the new app version
-          sed -i "s/0.0.0-chart-version/$app_version/g" chart/apl/Chart.yaml
-          sed -i "s/APP_VERSION_PLACEHOLDER/v$app_version/g" chart/apl/Chart.yaml
-
-          echo "Chart and values files updated successfully with version $app_version"
-
-          # Copy readme from repo into the charts and add tpl/chart-values.md
-          cp README.md chart/apl/
-          printf "\n\n" >>chart/apl/README.md
-          cat tpl/chart-values.md >>chart/apl/README.md
-
-          # Generate schema
-          npx js-yaml values-schema.yaml > chart/apl/values.schema.json
-
-          # Set the global id for git as it seems needed by the next step when a custom image is used
-          git config --global user.email $BOT_EMAIL
-          git config --global user.name $BOT_USERNAME
+          ci/scripts/prepare_chart_for_release.sh
 
       #TODO: Use the same user id on the container as in the runner to avoid the "dubious ownership" error
       - name: Mark repository as safe for Git

--- a/.github/workflows/create_rc.yml
+++ b/.github/workflows/create_rc.yml
@@ -45,47 +45,13 @@ jobs:
 
       - name: Create release candidate tag
         id: create_release
-        run: |
-
-          git config --global user.email "rc_githubactions@github.com"
-          git config --global user.name "Release Candidate GitHub Action "
-
-          git reset --hard ${{ env.commit_sha }}
-
-          # Use standard-version to determine the next version
-          npm run release -- --skip.commit --skip.tag --skip.changelog
-          new_version=$(jq -r '.version' package.json)
-          branch_name=rc/v${new_version%.*}
-          echo "rc_branch=$branch_name" >> $GITHUB_OUTPUT
-          release_branch_name=${branch_name//rc/release}
-
-          git reset --hard ${{ env.commit_sha }}
-
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
-            echo "Dry run enabled. The following commands would be executed:"
-            echo "git checkout -b $branch_name"
-            echo "npm run release -- --prerelease rc --skip.changelog --dry-run"
-            npm run release -- --prerelease rc --skip.changelog --dry-run
-            echo "git push -u origin $branch_name --follow-tags"
-          else
-            
-            git checkout -b $branch_name
-            npm run release -- --prerelease rc --skip.changelog
-            git push -u origin $branch_name --follow-tags
-          fi
-
-      - name: Create Github Release
-        id: create_github_release
         env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ env.commit_sha }}
         run: |
-          tag=$(jq -r '.version' package.json)
-          if [ "${{ github.event.inputs.dry_run }}" == "true" ]; then
-            echo "Dry run enabled. The following commands would be executed otherwise:"
-            echo gh release create "$tag" --title="Release Candidate: $tag" --notes="Automated release for $tag" --latest=false -p
-          else
-            gh release create "$tag" --title="Release Candidate: $tag" --notes="Automated release for $tag" --latest=false -p
-          fi
+          ci/scripts/create_rc.sh
+          echo "rc_branch=$(cat rc_branch_name.txt)" >> $GITHUB_OUTPUT
 
   chart-release:
     needs: create_patch_release
@@ -102,6 +68,9 @@ jobs:
           ref: ${{ needs.create_patch_release.outputs.rc_branch }}
 
       - name: Prepare chart
+        env:
+          BOT_EMAIL: ${{ secrets.BOT_EMAIL }}
+          BOT_USERNAME: ${{ secrets.BOT_USERNAME }}
         id: prepare_chart
         run: |
           # Retrieve the app version from package.json
@@ -122,8 +91,8 @@ jobs:
           npx js-yaml values-schema.yaml > chart/apl/values.schema.json
 
           # Set the global id for git as it seems needed by the next step when a custom image is used
-          git config --global user.email ${{ env.BOT_EMAIL }}
-          git config --global user.name ${{ env.BOT_USERNAME }}
+          git config --global user.email $BOT_EMAIL
+          git config --global user.name $BOT_USERNAME
 
       #TODO: Use the same user id on the container as in the runner to avoid the "dubious ownership" error
       - name: Mark repository as safe for Git

--- a/.github/workflows/patch_rc.yml
+++ b/.github/workflows/patch_rc.yml
@@ -9,27 +9,46 @@ on:
 
 jobs:
   patch_rc:
-    if: startsWith(github.event.head_commit.message, 'fix:') && !github.event.act
-    runs-on: ubuntu-latest
-    container:
-      image: linode/apl-tools:v2.8.2
-      options: --user 0 # See https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
+      - name: Analze commits since last rc release
+        id: analyze_commits
+        run: |
+
+          CURRENT_VERSION=$(jq '.version' package.json -r)
+          echo "Current version: $CURRENT_VERSION"
+          LATEST_TAG=$(git tag -l "v${CURRENT_VERSION%.*}*" | sort -V | tail -n 1)
+          echo "Latest tag: $LATEST_TAG"
+
+          echo "Commits since last rc release:"
+          git -P log --pretty=format:"%s" "${LATEST_TAG}..HEAD"
+          COMMITS=$(git log --pretty=format:"%s" "${LATEST_TAG}..HEAD")
+
+          if [[ $COMMITS == *"feat:"* || $COMMITS == *"fix:"* ]]; then
+            echo "RC_RELEASE=true" >> $GITHUB_ENV
+          else
+            echo "No feat/fix commits found. Skipping release."
+            echo "RC_RELEASE=false" >> $GITHUB_ENV
+          fi
+
       - name: Install dependencies
+        if: ${{ env.RC_RELEASE == 'true' }}
         run: |
           npm install standard-version
 
       - name: Configure Git
+        if: ${{ env.RC_RELEASE == 'true' }}
         run: |
           git config --global user.email "githubactions_rc@github.com"
           git config --global user.name "GitHub Action RC"
 
       - name: Release new RC version
+        if: ${{ env.RC_RELEASE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -40,6 +59,7 @@ jobs:
           gh release create "$TAG" --title="Release: $TAG" --notes="Automated release for $TAG" --latest=false -p
 
       - name: Prepare chart
+        if: ${{ env.RC_RELEASE == 'true' }}
         id: prepare_chart
         env:
           BOT_EMAIL: ${{ vars.BOT_EMAIL }}
@@ -48,7 +68,7 @@ jobs:
           ci/scripts/prepare_chart_for_release.sh
 
       - name: Create and publish otomi chart release
-        if: ${{ github.event.inputs.dry_run == 'false' }}
+        if: ${{ github.event.inputs.dry_run == 'false' }} && ${{ env.RC_RELEASE == 'true' }}
         id: chart_release
         uses: helm/chart-releaser-action@v1.7.0
         with:

--- a/.github/workflows/patch_rc.yml
+++ b/.github/workflows/patch_rc.yml
@@ -11,18 +11,24 @@ jobs:
   patch_rc:
     if: startsWith(github.event.head_commit.message, 'fix:') && !github.event.act
     runs-on: ubuntu-latest
+    container:
+      image: linode/apl-tools:v2.8.2
+      options: --user 0 # See https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Install dependencies
         run: |
           npm install standard-version
+
       - name: Configure Git
         run: |
           git config --global user.email "githubactions_rc@github.com"
           git config --global user.name "GitHub Action RC"
+
       - name: Release new RC version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,47 +39,10 @@ jobs:
           TAG="v$(jq '.version' package.json -r)"
           gh release create "$TAG" --title="Release: $TAG" --notes="Automated release for $TAG" --latest=false -p
 
-  chart-release:
-    needs: patch_rc
-    if: always() && contains(needs.patch_rc.result, 'success') && !github.event.act
-    runs-on: ubuntu-22.04
-    container:
-      image: linode/apl-tools:v2.8.2
-      options: --user 0 # See https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.ref}}
-
       - name: Prepare chart
         id: prepare_chart
         run: |
-          # Retrieve the app version from package.json
-          app_version=$(jq -r '.version' package.json)
-
-          # Update Chart.yaml and values.yaml with the new app version
-          sed -i "s/0.0.0-chart-version/$app_version/g" chart/apl/Chart.yaml
-          sed -i "s/APP_VERSION_PLACEHOLDER/v$app_version/g" chart/apl/Chart.yaml
-
-          echo "Chart and values files updated successfully with version $app_version"
-
-          # Copy readme from repo into the charts and add tpl/chart-values.md
-          cp README.md chart/apl/
-          printf "\n\n" >>chart/apl/README.md
-          cat tpl/chart-values.md >>chart/apl/README.md
-
-          # Generate schema
-          npx js-yaml values-schema.yaml > chart/apl/values.schema.json
-
-          # Set the global id for git as it seems needed by the next step when a custom image is used
-          git config --global user.email ${{ env.BOT_EMAIL }}
-          git config --global user.name ${{ env.BOT_USERNAME }}
-
-      #TODO: Use the same user id on the container as in the runner to avoid the "dubious ownership" error
-      - name: Mark repository as safe for Git
-        run: git config --global --add safe.directory /__w/apl-core/apl-core
+          ci/scripts/prepare_chart_for_release.sh
 
       - name: Create and publish otomi chart release
         if: ${{ github.event.inputs.dry_run == 'false' }}

--- a/.github/workflows/patch_rc.yml
+++ b/.github/workflows/patch_rc.yml
@@ -1,0 +1,87 @@
+name: Patch Release Candidate
+
+on:
+  push:
+    branches:
+      - rc/*
+    tags-ignore:
+      - '*'
+
+jobs:
+  patch_rc:
+    if: startsWith(github.event.head_commit.message, 'fix:') && !github.event.act
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          npm install standard-version
+      - name: Configure Git
+        run: |
+          git config --global user.email "githubactions_rc@github.com"
+          git config --global user.name "GitHub Action RC"
+      - name: Release new RC version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Detected "feat"/"fix"/"chore: trigger" commits. Running standard-version..."
+          npm run release -- --prerelease rc --skip.changelog 
+          git push --follow-tags
+          TAG="v$(jq '.version' package.json -r)"
+          gh release create "$TAG" --title="Release: $TAG" --notes="Automated release for $TAG" --latest=false -p
+
+  chart-release:
+    needs: patch_rc
+    if: always() && contains(needs.patch_rc.result, 'success') && !github.event.act
+    runs-on: ubuntu-22.04
+    container:
+      image: linode/apl-tools:v2.8.2
+      options: --user 0 # See https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref}}
+
+      - name: Prepare chart
+        id: prepare_chart
+        run: |
+          # Retrieve the app version from package.json
+          app_version=$(jq -r '.version' package.json)
+
+          # Update Chart.yaml and values.yaml with the new app version
+          sed -i "s/0.0.0-chart-version/$app_version/g" chart/apl/Chart.yaml
+          sed -i "s/APP_VERSION_PLACEHOLDER/v$app_version/g" chart/apl/Chart.yaml
+
+          echo "Chart and values files updated successfully with version $app_version"
+
+          # Copy readme from repo into the charts and add tpl/chart-values.md
+          cp README.md chart/apl/
+          printf "\n\n" >>chart/apl/README.md
+          cat tpl/chart-values.md >>chart/apl/README.md
+
+          # Generate schema
+          npx js-yaml values-schema.yaml > chart/apl/values.schema.json
+
+          # Set the global id for git as it seems needed by the next step when a custom image is used
+          git config --global user.email ${{ env.BOT_EMAIL }}
+          git config --global user.name ${{ env.BOT_USERNAME }}
+
+      #TODO: Use the same user id on the container as in the runner to avoid the "dubious ownership" error
+      - name: Mark repository as safe for Git
+        run: git config --global --add safe.directory /__w/apl-core/apl-core
+
+      - name: Create and publish otomi chart release
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        id: chart_release
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: chart
+          skip_existing: true
+          mark_as_latest: false
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/patch_rc.yml
+++ b/.github/workflows/patch_rc.yml
@@ -41,6 +41,9 @@ jobs:
 
       - name: Prepare chart
         id: prepare_chart
+        env:
+          BOT_EMAIL: ${{ vars.BOT_EMAIL }}
+          BOT_USERNAME: ${{ vars.BOT_USERNAME }}
         run: |
           ci/scripts/prepare_chart_for_release.sh
 

--- a/ci/scripts/create_rc.sh
+++ b/ci/scripts/create_rc.sh
@@ -38,8 +38,8 @@ git checkout -b "$branch_name"
 
 # Dry run or actual execution
 if [ "$DRY_RUN" == "true" ]; then
-    echo "Running in dry run mode. No changes will be pushed.\nBelow you can check the dry run of the release command"
-    npm run release -- --prerelease rc --skip.changelog --dry-run
+    echo -e "Running in dry run mode. No changes will be pushed."
+    npm run release -- --prerelease rc --skip.changelog
 else
     npm run release -- --prerelease rc --skip.changelog
     git push -u origin "$branch_name" --follow-tags

--- a/ci/scripts/create_rc.sh
+++ b/ci/scripts/create_rc.sh
@@ -44,8 +44,9 @@ else
     npm run release -- --prerelease rc --skip.changelog
     git push -u origin "$branch_name" --follow-tags
     git fetch --tags origin
-    echo "Creating GitHub release..."
-    gh release create "$new_version" --verify-tag --title="Release Candidate: $new_version" --notes="Automated release for $new_version" --latest=false -p
+    rc_version="v$(jq -r '.version' package.json)"
+    echo "Creating GitHub release: $rc_version"
+    gh release create "$rc_version" --verify-tag --title="Release Candidate: $rc_version" --notes="Automated release for $rc_version" --latest=false -p
 fi
 
 echo "Script completed successfully."

--- a/ci/scripts/create_rc_tag.sh
+++ b/ci/scripts/create_rc_tag.sh
@@ -1,0 +1,42 @@
+# This script creates a release candidate tag for commit set as COMMIT_SHA env var.
+# Input:
+# - COMMIT_SHA: The commit SHA to create the release candidate tag for.
+# - DRY_RUN: If set to true, the script will not create the tag, but will print the commands that would be executed.
+# - GITHUB_TOKEN: The GitHub token to use for authentication.
+# - BOT_EMAIL: The email address to use for the git commit.
+# - BOT_USERNAME: The username to use for the git commit.
+
+git config --global user.email $BOT_EMAIL
+git config --global user.name $BOT_USERNAME
+
+git reset --hard $COMMIT_SHA
+
+# Use standard-version to determine the next version
+npm run release -- --skip.commit --skip.tag --skip.changelog
+new_version=$(jq -r '.version' package.json)
+branch_name=rc/v${new_version%.*}
+echo "$branch_name" >> rc_branch_name.txt
+release_branch_name=${branch_name//rc/release}
+
+git reset --hard $COMMIT_SHA
+
+if [ "$DRY_RUN" == "true" ]; then
+    echo "Dry run enabled. The following commands would be executed:"
+    echo "git checkout -b $branch_name"
+    echo "npm run release -- --prerelease rc --skip.changelog --dry-run"
+    npm run release -- --prerelease rc --skip.changelog --dry-run
+    echo "git push -u origin $branch_name --follow-tags"
+else
+    git checkout -b $branch_name
+    npm run release -- --prerelease rc --skip.changelog
+    git push -u origin $branch_name --follow-tags
+fi
+
+tag=$(jq -r '.version' package.json)
+
+if [ "$DRY_RUN" == "true" ]; then
+    echo "Dry run enabled. The following commands would be executed otherwise:"
+    echo gh release create "$tag" --title="Release Candidate: $tag" --notes="Automated release for $tag" --latest=false -p
+else
+    gh release create "$tag" --title="Release Candidate: $tag" --notes="Automated release for $tag" --latest=false -p
+fi

--- a/ci/scripts/create_rc_tag.sh
+++ b/ci/scripts/create_rc_tag.sh
@@ -33,22 +33,17 @@ release_branch_name="${branch_name//rc/release}"
 echo "$branch_name" >> rc_branch_name.txt
 git reset --hard "$COMMIT_SHA"
 
+echo "Creating branch $branch_name..."
+git checkout -b "$branch_name"
+
 # Dry run or actual execution
 if [ "$DRY_RUN" == "true" ]; then
-    echo "Dry run enabled. The following commands would be executed:"
-    echo "git checkout -b $branch_name"
-    echo "npm run release -- --prerelease rc --skip.changelog --dry-run"
+    echo "Running in dry run mode. No changes will be pushed.\nBelow you can check the dry run of the release command"
     npm run release -- --prerelease rc --skip.changelog --dry-run
-    echo "git push -u origin $branch_name --follow-tags"
-    echo "git fetch --tags origin"
-    echo "gh release create \"$new_version\" --verify-tag --title=\"Release Candidate: $new_version\" --notes=\"Automated release for $new_version\" --latest=false -p"
 else
-    echo "Creating branch $branch_name..."
-    git checkout -b "$branch_name"
     npm run release -- --prerelease rc --skip.changelog
     git push -u origin "$branch_name" --follow-tags
     git fetch --tags origin
-
     echo "Creating GitHub release..."
     gh release create "$new_version" --verify-tag --title="Release Candidate: $new_version" --notes="Automated release for $new_version" --latest=false -p
 fi

--- a/ci/scripts/create_rc_tag.sh
+++ b/ci/scripts/create_rc_tag.sh
@@ -30,6 +30,7 @@ npm run release -- --skip.commit --skip.tag --skip.changelog
 new_version=$(jq -r '.version' package.json)
 branch_name="rc/v${new_version%.*}"
 release_branch_name="${branch_name//rc/release}"
+echo "$branch_name" >> rc_branch_name.txt
 git reset --hard "$COMMIT_SHA"
 
 # Dry run or actual execution

--- a/ci/scripts/prepare_chart_for_release.sh
+++ b/ci/scripts/prepare_chart_for_release.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script prepares the helm chart for release.
+# Input:
+# - BOT_EMAIL: The email address to use for the git commit.
+# - BOT_USERNAME: The username to use for the git commit.
+
+# Validate required environment variables
+: "${BOT_EMAIL:?BOT_EMAIL is required}"
+: "${BOT_USERNAME:?BOT_USERNAME is required}"
+
+# Retrieve the app version from package.json
+app_version=$(jq -r '.version' package.json)
+
+# Update Chart.yaml and values.yaml with the new app version
+sed -i "s/0.0.0-chart-version/$app_version/g" chart/apl/Chart.yaml
+sed -i "s/APP_VERSION_PLACEHOLDER/v$app_version/g" chart/apl/Chart.yaml
+
+echo "Chart and values files updated successfully with version $app_version"
+
+# Copy readme from repo into the charts and add tpl/chart-values.md
+cp README.md chart/apl/
+printf "\n\n" >>chart/apl/README.md
+cat tpl/chart-values.md >>chart/apl/README.md
+
+# Generate schema
+npx js-yaml values-schema.yaml > chart/apl/values.schema.json
+
+# Set the global id for git as it seems needed by the next step when a custom image is used
+git config --global user.email $BOT_EMAIL
+git config --global user.name $BOT_USERNAME


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->
This PR adds 2 new github worflows:
- a manually triggered one to create release candidates
- an automatically triggered one that patches the RC when a fix is added

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

A short summary of what the Release Candidate GitHub workflow does:

1. Takes input for a commit SHA(optional) and a dry_run flag(default=true).
2. Checks out the code and installs dependencies (standard-version).
3. Determines the commit to base the release candidate (RC) on.
4. Calculates a new version (without tagging or committing) using standard-version.
5. Creates an RC branch, and if not a dry run, makes a prerelease and pushes it.
6. Creates a GitHub release (skipped in dry run).
7. Checks out the new RC branch in a second job.
8. Updates Helm chart files with the new app version.
9. Appends README content and generates a schema file.
10. Publishes the chart using helm/chart-releaser-action (only if not a dry run).


## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
