### PR TITLE
ci: updated workflow to use a PAT instead of the default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/pr-auto-updater.yml
+++ b/.github/workflows/pr-auto-updater.yml
@@ -27,10 +27,10 @@ jobs:
           git config --global user.email ${{ vars.BOT_EMAIL }}
           git config --global user.name ${{ vars.BOT_USERNAME }}
 
-      - name: Authenticate GitHub CLI
-        run: echo "${{ secrets.BOT_TOKEN }}" | gh auth login --with-token
-
       - name: Update PR branches
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GH_PROMPT_DISABLED: 1
         run: |
           prs=$(gh pr list --state open --base main --json number,headRefName -q '.[] | [.number, .headRefName] | @tsv')
 

--- a/.github/workflows/pr-auto-updater.yml
+++ b/.github/workflows/pr-auto-updater.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PR_AUTOUPDATER_TOKEN }}
 
       - name: Install GitHub CLI
         run: |
@@ -27,7 +28,7 @@ jobs:
           git config --global user.name ${{ vars.BOT_USERNAME }}
 
       - name: Authenticate GitHub CLI
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+        run: echo "${{ secrets.PR_AUTOUPDATER_TOKEN }}" | gh auth login --with-token
 
       - name: Update PR branches
         run: |

--- a/.github/workflows/pr-auto-updater.yml
+++ b/.github/workflows/pr-auto-updater.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PR_AUTOUPDATER_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN }}
 
       - name: Install GitHub CLI
         run: |
@@ -28,7 +28,7 @@ jobs:
           git config --global user.name ${{ vars.BOT_USERNAME }}
 
       - name: Authenticate GitHub CLI
-        run: echo "${{ secrets.PR_AUTOUPDATER_TOKEN }}" | gh auth login --with-token
+        run: echo "${{ secrets.BOT_TOKEN }}" | gh auth login --with-token
 
       - name: Update PR branches
         run: |


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->

This PR updated the "PR Auto Updater" workflow to use a PAT instead of the default GITHIB_TOKEN since this one [can not trigger a workflow](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow). 
We need this workflow to trigger an image build in the affected branch after that branch is automatically updated with the lates changes on main.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

For more context:
- https://github.com/orgs/community/discussions/25702
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
