### PR TITLE
fix: move operator rbac to chart

### DIFF
--- a/charts/apl-gitea-operator/templates/rbac.yaml
+++ b/charts/apl-gitea-operator/templates/rbac.yaml
@@ -63,7 +63,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: apl-gitea-operator-trigger-template-pipeline-watcher
+  name: {{ include "apl-gitea-operator.fullname" . }}-trigger-template-pipeline-watcher
 rules:
   - apiGroups: ["tekton.dev"]
     resources: ["pipelines"]
@@ -75,13 +75,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: apl-gitea-operator-trigger-template-pipeline-binding
+  name: {{ include "apl-gitea-operator.fullname" . }}-trigger-template-pipeline-binding
 subjects:
   - kind: ServiceAccount
-    namespace: apl-gitea-operator
-    name: apl-gitea-operator
+    namespace: {{ .Release.Namespace }}
+    name: {{ include "apl-gitea-operator.serviceAccountName" . }}
 roleRef:
   kind: ClusterRole
-  name: apl-gitea-operator-trigger-template-pipeline-watcher
+  name: {{ include "apl-gitea-operator.fullname" . }}-trigger-template-pipeline-watcher
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/apl-gitea-operator/templates/rbac.yaml
+++ b/charts/apl-gitea-operator/templates/rbac.yaml
@@ -59,4 +59,29 @@ roleRef:
   kind: Role
   name: {{ include "apl-gitea-operator.fullname" . }}-pod-exec
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: apl-gitea-operator-trigger-template-pipeline-watcher
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelines"]
+    verbs: ["watch", "list", "get"]
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["triggertemplates"]
+    verbs: ["watch", "list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: apl-gitea-operator-trigger-template-pipeline-binding
+subjects:
+  - kind: ServiceAccount
+    namespace: apl-gitea-operator
+    name: apl-gitea-operator
+roleRef:
+  kind: ClusterRole
+  name: apl-gitea-operator-trigger-template-pipeline-watcher
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/team-ns/templates/rbac.yaml
+++ b/charts/team-ns/templates/rbac.yaml
@@ -220,18 +220,6 @@ rules:
   resources: ["secrets"]
   verbs: ["get", "watch", "list", "delete", "create", "update"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: apl-gitea-operator-team-{{ $v.teamId }}-trigger-template-pipeline-watcher
-rules:
-  - apiGroups: ["tekton.dev"]
-    resources: ["pipelines"]
-    verbs: ["watch", "list", "get"]
-  - apiGroups: ["triggers.tekton.dev"]
-    resources: ["triggertemplates"]
-    verbs: ["watch", "list", "get"]
----
 # RoleBinding for the above Role in team namespace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -246,17 +234,3 @@ roleRef:
   kind: Role
   name: apl-gitea-operator-service-account
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: apl-gitea-operator-team-{{ $v.teamId }}-trigger-template-pipeline-binding
-subjects:
-  - kind: ServiceAccount
-    namespace: apl-gitea-operator
-    name: apl-gitea-operator
-roleRef:
-  kind: ClusterRole
-  name: apl-gitea-operator-team-{{ $v.teamId }}-trigger-template-pipeline-watcher
-  apiGroup: rbac.authorization.k8s.io
----


### PR DESCRIPTION
## 📌 Summary

This PR moves roles and rolebindings required by the Gitea operator to the chart that deploys the application. Before this change, these resources were deployed along with every team. That causes a lot of unsuccessful connection attempts during the APL installation, before the first team (admin) is rolled out. After the first team, the roles are redundant with every new team.
While the effect might not be noticeable in a running cluster, this is likely to improve stability during install, since the load of Kubernetes API requests can trigger rate limiting.

## 🔍 Reviewer Notes

The apl-gitea-operator should not show any "Forbidden" error messages.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
