### PR TITLE
ci: fixed git config order

### DIFF
--- a/.github/workflows/create_rc.yml
+++ b/.github/workflows/create_rc.yml
@@ -41,6 +41,10 @@ jobs:
             echo "commit_sha=$commit_sha" >> $GITHUB_ENV
           fi
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Install dependencies
         run: |
           npm install standard-version

--- a/.github/workflows/patch_rc.yml
+++ b/.github/workflows/patch_rc.yml
@@ -45,19 +45,19 @@ jobs:
         run: |
           npm install standard-version
 
-      - name: Configure Git
-        if: ${{ env.RC_RELEASE == 'true' }}
-        run: |
-          git config --global user.email "githubactions_rc@github.com"
-          git config --global user.name "GitHub Action RC"
-
       - name: Release new RC version
         if: ${{ env.RC_RELEASE == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BOT_EMAIL: ${{ vars.BOT_EMAIL }}
+          BOT_USERNAME: ${{ vars.BOT_USERNAME }}
         run: |
           echo "Detected "feat"/"fix"/"chore: trigger" commits. Running standard-version..."
           npm run release -- --prerelease rc --skip.changelog 
+
+          git config --global user.email $BOT_EMAIL
+          git config --global user.name $BOT_USERNAME
+
           git push --follow-tags
           TAG="v$(jq '.version' package.json -r)"
           gh release create "$TAG" --title="Release: $TAG" --notes="Automated release for $TAG" --latest=false -p

--- a/.github/workflows/patch_rc.yml
+++ b/.github/workflows/patch_rc.yml
@@ -36,6 +36,10 @@ jobs:
             echo "RC_RELEASE=false" >> $GITHUB_ENV
           fi
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Install dependencies
         if: ${{ env.RC_RELEASE == 'true' }}
         run: |

--- a/.github/workflows/patch_rc.yml
+++ b/.github/workflows/patch_rc.yml
@@ -53,10 +53,9 @@ jobs:
           BOT_USERNAME: ${{ vars.BOT_USERNAME }}
         run: |
           echo "Detected "feat"/"fix"/"chore: trigger" commits. Running standard-version..."
-          npm run release -- --prerelease rc --skip.changelog 
-
           git config --global user.email $BOT_EMAIL
           git config --global user.name $BOT_USERNAME
+          npm run release -- --prerelease rc --skip.changelog 
 
           git push --follow-tags
           TAG="v$(jq '.version' package.json -r)"


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->

Fixing the order when we configure git identity. the `npm release` command needs an identity becuse it needs to create a branch and tag this the git configuration must happen before.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
