### PR TITLE
ci: removed standard-version config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,11 +166,6 @@
     "bootstrap-dev-with-repo": "CI=1 ENV_DIR=/tmp/otomi-bootstrap-dev binzx/otomi bootstrap",
     "bootstrap-tests-fixtures": "CI=1 ENV_DIR=$PWD/tests/fixtures binzx/otomi bootstrap"
   },
-  "standard-version": {
-    "skip": {
-      "tag": true
-    }
-  },
   "type": "commonjs",
   "version": "4.4.0"
 }


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->
While trying to generate our first release candidate, the pipeline failed because of a missing tag which should have been created by [running the release command](https://github.com/linode/apl-core/blob/4305ef11d1ff5861fc21c777a4767acb38350e0b/ci/scripts/create_rc.sh#L44C5-L44C56).
Apparently this behavior was disabled in packages.json. 

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
