### PR TITLE
ci: updated github token to bot token

### DIFF
--- a/.github/workflows/patch_rc.yml
+++ b/.github/workflows/patch_rc.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Release new RC version
         if: ${{ env.RC_RELEASE == 'true' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
           BOT_EMAIL: ${{ vars.BOT_EMAIL }}
           BOT_USERNAME: ${{ vars.BOT_USERNAME }}
         run: |
@@ -79,4 +79,4 @@ jobs:
           skip_existing: true
           mark_as_latest: false
         env:
-          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_TOKEN: '${{ secrets.BOT_TOKEN }}'

--- a/package.json
+++ b/package.json
@@ -166,11 +166,6 @@
     "bootstrap-dev-with-repo": "CI=1 ENV_DIR=/tmp/otomi-bootstrap-dev binzx/otomi bootstrap",
     "bootstrap-tests-fixtures": "CI=1 ENV_DIR=$PWD/tests/fixtures binzx/otomi bootstrap"
   },
-  "standard-version": {
-    "skip": {
-      "tag": true
-    }
-  },
   "type": "commonjs",
   "version": "4.4.0"
 }

--- a/package.json
+++ b/package.json
@@ -166,6 +166,11 @@
     "bootstrap-dev-with-repo": "CI=1 ENV_DIR=/tmp/otomi-bootstrap-dev binzx/otomi bootstrap",
     "bootstrap-tests-fixtures": "CI=1 ENV_DIR=$PWD/tests/fixtures binzx/otomi bootstrap"
   },
+  "standard-version": {
+    "skip": {
+      "tag": true
+    }
+  },
   "type": "commonjs",
   "version": "4.4.0"
 }


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->
This PR updates the token used by the "Patch Release Candidate" pipeline so that after it patches a RC, it also triggers the build pipeline. Currently commits pushed with the GITHUB_TOKEN [do not trigger a pipeline run](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow). 

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
