### PR TITLE
fix: set resource limits to enforce resource defaults for containers

### DIFF
--- a/charts/team-ns/templates/limitrange.yaml
+++ b/charts/team-ns/templates/limitrange.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-resource-constraint
+spec:
+  limits:
+  - default: # this section defines default limits
+      cpu: 200m
+      memory: 64Mi
+    defaultRequest: # this section defines default requests
+      cpu: 50m
+      memory: 32Mi
+    type: Container


### PR DESCRIPTION
## 📌 Summary

Tekton init containers does not specify resources thus resource quota is blocking it.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
