### PR TITLE
fix: updated keycloak init container version rendering

### DIFF
--- a/values/keycloak-operator/keycloak-operator-cr.gotmpl
+++ b/values/keycloak-operator/keycloak-operator-cr.gotmpl
@@ -47,7 +47,7 @@ spec:
           emptyDir: {}
         initContainers:
         - name: init-container-theme-copy # Otomi branding init container
-          image: docker.io/linode/apl-console:{{ $v.versions.consoleLogin }}
+          image: docker.io/linode/apl-console:v{{ $v.versions.consoleLogin }}
           resources: {{ $k.resources.keycloak | toYaml  | nindent 12 }}
           command: 
           - sh 


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->

With this PR we can be more consistent in setting versions for our tools. Now consoleLogin accepts a version tag without the `v` prefix as the other components.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
