### PR TITLE
fix: always deploy ingress for team core apps 

### DIFF
--- a/charts/team-ns/templates/limitrange.yaml
+++ b/charts/team-ns/templates/limitrange.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: LimitRange
 metadata:
-  name: cpu-resource-constraint
+  name: team-ns-resource-defaults
+  labels: {{- include "team-ns.chart-labels" . | nindent 4 }}
 spec:
   limits:
   - default: # this section defines default limits

--- a/values/team-ns/team-ns.gotmpl
+++ b/values/team-ns/team-ns.gotmpl
@@ -11,13 +11,15 @@ buildStorageClassName: {{ $v._derived.buildStorageClassName }}
 
 {{- $coreTeamServices := list }}
 {{- range $s := $v.teamApps }}
-  {{- if and ($a | get $s.name | get "enabled" true) (hasKey $s "ingress") $v.otomi.isMultitenant }}
+  {{- if and (hasKey $s "ingress") $v.otomi.isMultitenant }}
     {{- range $ing := $s.ingress }}
       {{- $svc := merge $ing (dict "isCore" true "name" $s.name "ownHost" ($s | get "ownHost" false)) }}
       {{- $coreTeamServices = append $coreTeamServices $svc }}
     {{- end }}
   {{- end }}
 {{- end }}
+
+
 
 {{- $teamResourceQuotas := dict }}
 {{- range $team | get "settings.resourceQuota" list }}


### PR DESCRIPTION
## 📌 Summary

This change ensures that ingress for team apps is always created regardless of app being enabled or not.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
