### PR TITLE
fix: remove resourcequota and limitrange limits

### DIFF
--- a/charts/team-ns/templates/limitrange.yaml
+++ b/charts/team-ns/templates/limitrange.yaml
@@ -5,10 +5,7 @@ metadata:
   labels: {{- include "team-ns.chart-labels" . | nindent 4 }}
 spec:
   limits:
-  - default: # this section defines default limits
-      cpu: 200m
+  - defaultRequest: # this section defines default requests
+      cpu: 100m
       memory: 64Mi
-    defaultRequest: # this section defines default requests
-      cpu: 50m
-      memory: 32Mi
     type: Container

--- a/helmfile.d/snippets/defaults.gotmpl
+++ b/helmfile.d/snippets/defaults.gotmpl
@@ -197,12 +197,8 @@ environments:
                   value: "0"
                 - name: services.nodeports
                   value: "0"
-                - name: limits.cpu
-                  value: "24"
                 - name: requests.cpu
                   value: "24"
-                - name: limits.memory
-                  value: "32Gi"
                 - name: requests.memory
                   value: "32Gi"
                 - name: pods


### PR DESCRIPTION
## 📌 Summary

The ResourceQuota and LimitRange limits are not yet compatible with the whole platform, thus for time being we need to remove them.

## 🔍 Reviewer Notes
Once ResourceQuota  limit is set then every pod is required to have them defined. We initially assumed that by defining LimitRange solves that issue. That turned out to be a wrong assumption because some Pod are OOM killed due to the default low memory limits. 

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
