### PR TITLE
fix: team access to loki logs

### DIFF
--- a/values/loki/auth-config.gotmpl
+++ b/values/loki/auth-config.gotmpl
@@ -4,6 +4,6 @@ users:
     orgid: admins
   {{- range $id, $team := .teams }}
   - username: {{ $id }}
-    password: {{ $team | get "password" "XXXX" }}
+    password: {{ $team.settings.password }}
     orgid: {{ $id }}
   {{- end }}


### PR DESCRIPTION
## 📌 Summary

After wrapping team settings under the settings property we did not anticipate changes required for Loki.
That issue was not caught because the templating logic had a fallback to 'XXX' value.

## 🔍 Reviewer Notes



## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
