### PR TITLE
chore: set versions to main

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,5 +1,5 @@
-api: 4.3.2
-console: 4.2.3
-consoleLogin: 4.2.3
-tasks: 3.10.0
-tools: 2.8.7
+api: main
+console: main
+consoleLogin: main
+tasks: main
+tools: main


### PR DESCRIPTION
## 📌 Summary

This PR sets the versions of other components back to `main`, as prior to the release.

## 🔍 Reviewer Notes

This is the common development setup and does not require specific testing.

## 🧹 Checklist

N/A
