### PR TITLE
fix: remove finalizers and labels from sealed secrets

### DIFF
--- a/charts/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/charts/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -89,6 +89,14 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
+                      finalizers:
+                        items:
+                          type: string
+                        type: array
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
                       name:
                         type: string
                       namespace:

--- a/charts/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
+++ b/charts/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
@@ -89,14 +89,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      finalizers:
-                        items:
-                          type: string
-                        type: array
-                      labels:
-                        additionalProperties:
-                          type: string
-                        type: object
                       name:
                         type: string
                       namespace:

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
-api: main
+api: APL-765
 console: main
 consoleLogin: main
 tasks: main


### PR DESCRIPTION
## 📌 Summary

Removes finalizer and labels from Sealedsecrets, they were causing a sync error in argoCD.