### PR TITLE
fix: set default k8s version 1.32

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,7 +51,7 @@ on:
           - "['1.31']"
           - "['1.32']"
           - "['1.33']"
-        default: "['1.33']"
+        default: "['1.32']"
       install_profile:
         description: APL installation profile
         default: minimal-with-team


### PR DESCRIPTION
## 📌 Summary

set default version to k8s v1.32 as v1.33 is not supported on linode yet

<!-- What does this PR do? Why is it needed? -->

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
