### PR TITLE
fix: annotate Gitea volume

### DIFF
--- a/upgrades/pre/upgrade-4-6-0.sh
+++ b/upgrades/pre/upgrade-4-6-0.sh
@@ -22,3 +22,5 @@ if [[ $(kubectl get applications.argoproj.io -n argocd keycloak-keycloak-operato
   kubectl delete --ignore-not-found crd keycloakrealmimports.k8s.keycloak.org
   kubectl delete --ignore-not-found crd keycloaks.k8s.keycloak.org
 fi
+
+kubectl annotate -n gitea pvc/data-gitea-0 helm.sh/resource-policy=keep


### PR DESCRIPTION
## 📌 Summary

This PR adds an annotation in the pre-upgrade for avoiding Helm to remove the Gitea repo volume under any circumstances.

## 🔍 Reviewer Notes

The PVC of Gitea disappearing is not the rule, but has been observed in an upgrade scenario. This annotation should eliminate that possibility.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
