### PR TITLE
chore: bump ingress-nginx from v1.11.5 tov1.11.6

### DIFF
--- a/charts/ingress-nginx/values.yaml
+++ b/charts/ingress-nginx/values.yaml
@@ -26,7 +26,7 @@ controller:
     ## for backwards compatibility consider setting the full image url via the repository value below
     ## use *either* current default registry/image or repository format or installing chart by providing the values.yaml will fail
     ## repository:
-    tag: "v1.11.5"
+    tag: "v1.11.6"
     digest: sha256:a1cbad75b0a7098bf9325132794dddf9eef917e8a7fe246749a4cea7ff6f01eb
     digestChroot: sha256:ec9df3eb6b06563a079ee46045da94cbf750f7dbb16fdbcb9e3265b551ed72ad
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## 📌 Summary

Bump ingress-nginx from v1.11.5 tov1.11.6

## 🔍 Reviewer Notes

https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.11.6

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
