### PR TITLE
fix: actually check for difference between files

### DIFF
--- a/src/common/crypt.ts
+++ b/src/common/crypt.ts
@@ -195,7 +195,7 @@ export const encrypt = async (path = env.ENV_DIR, ...files: string[]): Promise<v
           return true
         }
 
-        // Compare timestamps
+        // Compare files
         const specsAreDifferent = await filesAreDifferent(file, d)
         if (specsAreDifferent) {
           d.info(`Encrypting ${file}, difference found between encrypted and .dec file`)

--- a/src/common/crypt.ts
+++ b/src/common/crypt.ts
@@ -5,7 +5,7 @@ import { chunk } from 'lodash'
 import { $, cd, ProcessOutput } from 'zx'
 import { terminal } from './debug'
 import { cleanEnv, cliEnvSpec, env, isCli } from './envalid'
-import { filesAreDifferent, readdirRecurse, rootDir } from './utils'
+import { hasFileDifference, readdirRecurse, rootDir } from './utils'
 import { BasicArguments } from './yargs'
 
 export interface Arguments extends BasicArguments {
@@ -196,7 +196,7 @@ export const encrypt = async (path = env.ENV_DIR, ...files: string[]): Promise<v
         }
 
         // Compare files
-        const specsAreDifferent = await filesAreDifferent(file, d)
+        const specsAreDifferent = await hasFileDifference(file, `${file}.dec`)
         if (specsAreDifferent) {
           d.info(`Encrypting ${file}, difference found between encrypted and .dec file`)
           return true

--- a/src/common/crypt.ts
+++ b/src/common/crypt.ts
@@ -198,7 +198,7 @@ export const encrypt = async (path = env.ENV_DIR, ...files: string[]): Promise<v
         // Compare timestamps
         const specsAreDifferent = await filesAreDifferent(file, d)
         if (specsAreDifferent) {
-          d.info(`Encrypting ${file}, different from ${file}.dec`)
+          d.info(`Encrypting ${file}, difference found between encrypted and .dec file`)
           return true
         }
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -9,7 +9,7 @@ import { dump, load } from 'js-yaml'
 import { omit } from 'lodash'
 import { dirname, join, resolve } from 'path'
 import { $, ProcessOutput } from 'zx'
-import { OtomiDebugger } from './debug'
+import { terminal } from './debug'
 import { env } from './envalid'
 
 const packagePath = process.cwd()
@@ -260,17 +260,18 @@ function hashContent(content: Buffer): string {
   return createHash('sha256').update(content).digest('hex')
 }
 
-export async function filesAreDifferent(file: string, debug: OtomiDebugger): Promise<boolean> {
+export async function hasFileDifference(filePathOne: string, filePathTwo: string): Promise<boolean> {
+  const d = terminal(`common:utils:hasFileDifference`)
   try {
-    const originalContent = await readFile(file)
-    const decryptedContent = await readFile(`${file}.dec`)
+    const fileOneContent = await readFile(filePathOne)
+    const fileTwoContent = await readFile(filePathTwo)
 
-    const originalHash = hashContent(originalContent)
-    const decryptedHash = hashContent(decryptedContent)
+    const fileOneHash = hashContent(fileOneContent)
+    const fileTwoHash = hashContent(fileTwoContent)
 
-    return originalHash !== decryptedHash
+    return fileOneHash !== fileTwoHash
   } catch (err) {
-    debug.error(`Error reading files: ${err}`)
+    d.error(`Error reading files: ${err}`)
     return true // If there's an error, assume files are different
   }
 }


### PR DESCRIPTION
## 📌 Summary

This PR changes the way that we check for differences between the dec and encrypted files. Because of the session stack the time difference was too small to actually see if there was a difference or not.
