### PR TITLE
chore: Upgrade Kiali Operator

### DIFF
--- a/chart/chart-index/Chart.yaml
+++ b/chart/chart-index/Chart.yaml
@@ -50,7 +50,7 @@ dependencies:
     version: 24.5.7
     repository: https://charts.bitnami.com/bitnami
   - name: kiali-operator
-    version: 1.86.1
+    version: 2.10.0
     repository: https://kiali.org/helm-charts
   - name: knative-operator
     version: 0.1.0

--- a/charts/kiali-operator/Chart.yaml
+++ b/charts/kiali-operator/Chart.yaml
@@ -1,19 +1,20 @@
 apiVersion: v2
-name: kiali-operator
-description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details.
-version: 1.86.1
-appVersion: v1.86.1
+appVersion: v2.10.0
+description: Kiali is an open source project for service mesh observability, refer
+  to https://www.kiali.io for details.
 home: https://github.com/kiali/kiali-operator
-maintainers:
-- name: Kiali
-  email: kiali-users@googlegroups.com
-  url: https://kiali.io
+icon: https://raw.githubusercontent.com/kiali/kiali.io/current/assets/icons/logo.svg
 keywords:
 - istio
 - kiali
 - operator
+maintainers:
+- email: kiali-users@googlegroups.com
+  name: Kiali
+  url: https://kiali.io
+name: kiali-operator
 sources:
 - https://github.com/kiali/kiali
 - https://github.com/kiali/kiali-operator
 - https://github.com/kiali/helm-charts
-icon: https://raw.githubusercontent.com/kiali/kiali.io/current/assets/icons/logo.svg
+version: 2.10.0

--- a/charts/kiali-operator/crds/crds.yaml
+++ b/charts/kiali-operator/crds/crds.yaml
@@ -21,4 +21,4 @@ spec:
       openAPIV3Schema:
         type: object
         x-kubernetes-preserve-unknown-fields: true
----
+...

--- a/charts/kiali-operator/templates/_helpers.tpl
+++ b/charts/kiali-operator/templates/_helpers.tpl
@@ -35,6 +35,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "kiali-operator.labels" -}}
+{{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels }}
+{{- end }}
 helm.sh/chart: {{ include "kiali-operator.chart" . }}
 app: {{ include "kiali-operator.name" . }}
 {{ include "kiali-operator.selectorLabels" . }}
@@ -42,7 +45,6 @@ app: {{ include "kiali-operator.name" . }}
 version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: "kiali-operator"
 {{- end }}
 

--- a/charts/kiali-operator/templates/clusterrole.yaml
+++ b/charts/kiali-operator/templates/clusterrole.yaml
@@ -36,17 +36,6 @@ rules:
   - create
   - list
   - watch
-{{- if gt (len .Values.secretReader) 0 }}
-- apiGroups: [""]
-  resourceNames:
-  {{- range .Values.secretReader }}
-  - {{ . }}
-  {{- end }}
-  resources:
-  - secrets
-  verbs:
-  - get
-{{- end }}
 - apiGroups: [""]
   resourceNames:
   - kiali-signing-key
@@ -58,6 +47,15 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups: [""]
+  resourceNames:
+  - kiali-multi-cluster-secret
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups: ["apps"]
   resources:
@@ -113,7 +111,7 @@ rules:
   - list
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources:
-  {{- if or (and (.Values.cr.create) (has "**" .Values.cr.spec.deployment.accessible_namespaces)) (.Values.clusterRoleCreator) }}
+  {{- if or (and (.Values.cr.create) (.Values.cr.spec.deployment.cluster_wide_access)) (.Values.clusterRoleCreator) }}
   - clusterrolebindings
   - clusterroles
   {{- end }}
@@ -312,4 +310,11 @@ rules:
   - tokenreviews
   verbs:
   - create
----
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+...

--- a/charts/kiali-operator/templates/clusterrolebinding.yaml
+++ b/charts/kiali-operator/templates/clusterrolebinding.yaml
@@ -8,9 +8,9 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kiali-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
 roleRef:
   kind: ClusterRole
   name: {{ include "kiali-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
----
+...

--- a/charts/kiali-operator/templates/deployment.yaml
+++ b/charts/kiali-operator/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kiali-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
   {{- include "kiali-operator.labels" . | nindent 4 }}
 spec:
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       name: {{ include "kiali-operator.fullname" . }}
-      namespace: {{ .Release.Namespace }}
+      namespace: "{{ .Release.Namespace }}"
       labels:
         # required for the operator SDK metric service selector
         name: {{ include "kiali-operator.fullname" . }}
@@ -50,6 +50,26 @@ spec:
         - "--zap-log-level=info"
         - "--leader-election-id={{ include "kiali-operator.fullname" . }}"
         - "--watches-file=./$(WATCHES_FILE)"
+        - "--health-probe-bind-address=:6789"
+        - "--metrics-bind-address=:8080"
+        terminationMessagePolicy: FallbackToLogsOnError
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 6789
+          periodSeconds: 30
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 6789
+          periodSeconds: 30
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 6789
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 6
         securityContext:
         {{- if .Values.securityContext }}
         {{- toYaml .Values.securityContext | nindent 10 }}
@@ -87,9 +107,7 @@ spec:
         - name: ALLOW_SECURITY_CONTEXT_OVERRIDE
           value: {{ .Values.allowSecurityContextOverride | quote }}
         - name: ALLOW_ALL_ACCESSIBLE_NAMESPACES
-          value: {{ or (and (.Values.cr.create) (has "**" .Values.cr.spec.deployment.accessible_namespaces)) (.Values.allowAllAccessibleNamespaces) | quote }}
-        - name: ACCESSIBLE_NAMESPACES_LABEL
-          value: {{ .Values.accessibleNamespacesLabel | quote }}
+          value: {{ or (and (.Values.cr.create) (.Values.cr.spec.deployment.cluster_wide_access)) (.Values.allowAllAccessibleNamespaces) | quote }}
         - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
           value: "100"
         - name: ANSIBLE_DEBUG_LOGS
@@ -135,4 +153,4 @@ spec:
         emptyDir: {}
       affinity:
       {{- toYaml .Values.affinity | nindent 8 }}
----
+...

--- a/charts/kiali-operator/templates/kiali-cr.yaml
+++ b/charts/kiali-operator/templates/kiali-cr.yaml
@@ -4,9 +4,9 @@ apiVersion: kiali.io/v1alpha1
 kind: Kiali
 metadata:
   {{- if .Values.watchNamespace }}
-  namespace: {{ .Values.watchNamespace }}
+  namespace: "{{ .Values.watchNamespace }}"
   {{- else if .Values.cr.namespace }}
-  namespace: {{ .Values.cr.namespace }}
+  namespace: "{{ .Values.cr.namespace }}"
   {{- end }}
   name: {{ .Values.cr.name }}
   labels:
@@ -18,5 +18,5 @@ metadata:
     {{- end }}
 spec:
   {{- toYaml .Values.cr.spec | nindent 2 }}
----
+...
 {{ end }}

--- a/charts/kiali-operator/templates/ossmconsole-crd.yaml
+++ b/charts/kiali-operator/templates/ossmconsole-crd.yaml
@@ -30,5 +30,5 @@ spec:
       openAPIV3Schema:
         type: object
         x-kubernetes-preserve-unknown-fields: true
----
+...
 {{- end }}

--- a/charts/kiali-operator/templates/serviceaccount.yaml
+++ b/charts/kiali-operator/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kiali-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: "{{ .Release.Namespace }}"
   labels:
   {{- include "kiali-operator.labels" . | nindent 4 }}
 {{- if .Values.image.pullSecrets }}
@@ -12,4 +12,4 @@ imagePullSecrets:
 - name: {{ . }}
 {{- end }}
 {{- end }}
----
+...

--- a/charts/kiali-operator/values.yaml
+++ b/charts/kiali-operator/values.yaml
@@ -2,13 +2,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 image: # see: https://quay.io/repository/kiali/kiali-operator?tab=tags
-  repo: ${HELM_IMAGE_REPO} # quay.io/kiali/kiali-operator
-  tag: ${HELM_IMAGE_TAG} # version string like v1.39.0 or a digest hash
+  repo: quay.io/kiali/kiali-operator # quay.io/kiali/kiali-operator
+  tag: v2.10.0 # version string like v1.39.0 or a digest hash
   digest: "" # use "sha256" if tag is a sha256 hash (do NOT prefix this value with a "@")
   pullPolicy: Always
   pullSecrets: []
 
 # Deployment options for the operator pod.
+extraLabels: {}
 nodeSelector: {}
 podAnnotations: {}
 podLabels: {}
@@ -39,19 +40,10 @@ debug:
 watchNamespace: ""
 
 # Set to true if you want the operator to be able to create cluster roles. This is necessary
-# if you want to support Kiali CRs with spec.deployment.accessible_namespaces of '**'.
+# if you want to support Kiali CRs with spec.deployment.cluster_wide_access=true.
 # Setting this to "true" requires allowAllAccessibleNamespaces to be "true" also.
-# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.accessible_namespaces is ['**'].
+# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.cluster_wide_access=true.
 clusterRoleCreator: true
-
-# Set to a list of secrets in the cluster that the operator will be allowed to read. This is necessary if you want to
-# support Kiali CRs with spec.kiali_feature_flags.certificates_information_indicators.enabled=true.
-# The secrets in this list will be the only ones allowed to be specified in any Kiali CR (in the setting
-# spec.kiali_feature_flags.certificates_information_indicators.secrets).
-# If you set this to an empty list, the operator will not be given permission to read any additional secrets
-# found in the cluster, and thus will only support a value of "false" in the Kiali CR setting
-# spec.kiali_feature_flags.certificates_information_indicators.enabled.
-secretReader: ['cacerts', 'istio-ca-secret']
 
 # Set to true if you want to allow the operator to only be able to install Kiali in view-only-mode.
 # The purpose for this setting is to allow you to restrict the permissions given to the operator itself.
@@ -83,21 +75,11 @@ allowAdHocOSSMConsoleImage: false
 allowSecurityContextOverride: false
 
 # allowAllAccessibleNamespaces tells the operator to allow a user to be able to configure Kiali
-# to access all namespaces in the cluster via spec.deployment.accessible_namespaces=['**'].
-# If this is false, the user must specify an explicit list of namespaces in the Kiali CR.
+# to access all namespaces in the cluster via spec.deployment.cluster_wide_access=true.
+# If this is false, the user must specify an explicit set of namespaces in the Kiali CR via spec.deployment.discovery_selectors.
 # Setting this to "true" requires clusterRoleCreator to be "true" also.
-# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.accessible_namespaces is ['**'].
+# Note that this will be overriden to "true" if cr.create is true and cr.spec.deployment.cluster_wide_access=true.
 allowAllAccessibleNamespaces: true
-
-# accessibleNamespacesLabel restricts the namespaces that a user can add to the Kiali CR spec.deployment.accessible_namespaces.
-# This value is either an empty string (which disables this feature) or a label name with an optional label value
-# (e.g. "mylabel" or "mylabel=myvalue"). Only namespaces that have that label will be permitted in
-# spec.deployment.accessible_namespaces. Any namespace not labeled properly but specified in accessible_namespaces will cause
-# the operator to abort the Kiali installation.
-# If just a label name (but no label value) is specified, the label value the operator will look for is the value of
-# the Kiali CR's spec.istio_namespace. In other words, the operator will look for the named label whose value must be the name
-# of the Istio control plane namespace (which is typically, but not necessarily, "istio-system").
-accessibleNamespacesLabel: ""
 
 # watchesFile: If specified, this determines what watches file will be used to configure the operator. There are four different
 # files that can be selected: (a) `watches-os.yaml`, (b) `watches-os-ns.yaml`, (c) `watches-k8s.yaml` or (d) `watches-k8s-ns.yaml`.
@@ -107,8 +89,7 @@ accessibleNamespacesLabel: ""
 # the default behavior and is not necessary if your Kiali CRs will have `spec.deployment.cluster_wide_access` set to `true`.
 watchesFile: ""
 
-# For what a Kiali CR spec can look like, see:
-# https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml
+# For what a Kiali CR spec can look like, see: https://kiali.io/docs/configuration/kialis.kiali.io/
 cr:
   create: false
   name: kiali
@@ -122,5 +103,4 @@ cr:
 
   spec:
     deployment:
-      accessible_namespaces:
-      - '**'
+      cluster_wide_access: true

--- a/values/kiali-operator/kiali-operator.gotmpl
+++ b/values/kiali-operator/kiali-operator.gotmpl
@@ -2,16 +2,12 @@
 {{- $k := $v.apps.kiali }}
 {{- $kk := $v.apps.keycloak }}
 
-{{- with .Values.otomi | get "globalPullSecret" nil }}
 image:
+  pullPolicy: IfNotPresent
+{{- with .Values.otomi | get "globalPullSecret" nil }}
   pullSecrets:
     - name: otomi-pullsecret-global
 {{- end }}
-
-
-image:
-  repo: quay.io/kiali/kiali-operator
-  tag: v1.86.1
 
 cr:
   create: true
@@ -26,12 +22,10 @@ cr:
         issuer_uri: {{ $v._derived.oidcBaseUrl }}
         username_claim: email
     deployment:
-      pod_annotations:
-        sidecar.istio.io/inject: "true"
-      ingress_enabled: false
+      ingress:
+        enabled: false
       namespace: kiali
       resources: {{- $k.resources.pod | toYaml  | nindent 8 }}
-      verbose_mode: "4"
     external_services:
       grafana:
         enabled: false
@@ -63,21 +57,15 @@ cr:
         url: http://po-prometheus.monitoring:9090/
       tracing:
         enabled: true
-        in_cluster_url: "http://query-frontend.tempo:3100"
+        internal_url: "http://query-frontend.tempo:3100"
         provider: tempo
         use_grpc: false
-        url: "http://grafana.{{ $v.cluster.domainSuffix }}/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22tempo%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D"
+        external_url: "http://grafana.{{ $v.cluster.domainSuffix }}/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22tempo%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D"
     istio_component_namespaces:
       prometheus: monitoring
     istio_namespace: istio-system
-    kiali_feature_flags:
-      certificates_information_indicators:
-        enabled: true
-        secrets:
-        - cacerts
-        - istio-ca-secret
     server:
       web_root: ""
       web_fqdn: kiali.{{ $v.cluster.domainSuffix }}
 
-resources: {{- $k.resources.operator | toYaml  | nindent 2 }}
+resources: {{- $k.resources.operator | toYaml | nindent 2 }}

--- a/values/kiali-operator/kiali-operator.gotmpl
+++ b/values/kiali-operator/kiali-operator.gotmpl
@@ -54,10 +54,10 @@ cr:
         cache_enabled: true
         cache_expiration: 1800
         is_core: false
-        url: http://po-prometheus.monitoring:9090/
+        url: http://po-prometheus.monitoring.svc.cluster.local:9090/
       tracing:
         enabled: true
-        internal_url: "http://query-frontend.tempo:3100"
+        internal_url: http://tempo-query-frontend.tempo.svc.cluster.local:3100
         provider: tempo
         use_grpc: false
         external_url: "http://grafana.{{ $v.cluster.domainSuffix }}/explore?orgId=1&left=%7B%22datasource%22:%22tempo%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22tempo%22,%22uid%22:%22tempo%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D"


### PR DESCRIPTION
## 📌 Summary

This PR implements a major upgrade of the Kiali Operator, which is required for compatibility with the newer Istio version v1.26.x. It also includes some minor configuration updates and fixes. 

## 🔍 Reviewer Notes

Once the Kiali app is enabled, it should be possible to review the Istio mesh configuration. Tracing configuration had not been implemented completely yet before and should be picked up later.

The session timeout is a known issue and not new with this release: https://github.com/kiali/kiali/issues/5233

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
