### PR TITLE
ci: restart dev apl-operator after main branch update

### DIFF
--- a/ci/scripts/trigger_dev.sh
+++ b/ci/scripts/trigger_dev.sh
@@ -9,30 +9,11 @@ if [ -z "$KUBECONFIG" ]; then
   export KUBECONFIG=$(pwd)/.kubeconfig
 fi
 
-echo "Restart deployments platform deployments"
+echo "Restart platform deployments"
 kubectl -n otomi rollout restart deployment/otomi-api
 kubectl -n otomi rollout restart deployment/otomi-console
 kubectl rollout restart deployment -n apl-harbor-operator apl-harbor-operator
 kubectl rollout restart deployment -n apl-keycloak-operator apl-keycloak-operator
 kubectl rollout restart deployment -n apl-gitea-operator apl-gitea-operator
 kubectl rollout restart deployment -n otomi-operator otomi-operator
-
-echo "Extract Gitea username, password, and values repo git url"
-export USERNAME=$(kubectl get secret -n apl-operator gitea-credentials -ojsonpath='{.data.GIT_USERNAME}' | base64 -d)
-export PASSWORD=$(kubectl get secret -n apl-operator gitea-credentials -ojsonpath='{.data.GIT_PASSWORD}' | base64 -d)
-export URL=$(kubectl get ingress nginx-team-admin-platform-public-open -n istio-system -o json | jq -r '.spec.rules[] | select(.host | startswith("gitea")) | .host')
-
-if [ -n "$BOT_USERNAME" ] && [ -n "$BOT_EMAIL" ]; then
-  echo "Configure Git user details for committing changes"
-  git config --global user.name "$BOT_USERNAME"
-  git config --global user.email "$BOT_EMAIL"
-fi
-
-echo "Clone the values repository using the decoded credentials"
-git clone --depth 2 https://$USERNAME:$PASSWORD@$URL/otomi/values.git dev-values 2>/dev/null
-cd dev-values
-
-echo "Create an empty commit to trigger the pipeline and push it to the main branch"
-git commit --allow-empty -m "Triggering pipeline for ${COMMIT_SHA}"
-git push origin main
-echo "Successfully triggered the pipeline for the dev environment"
+kubectl rollout restart deployment -n apl-operator apl-operator


### PR DESCRIPTION
## 📌 Summary

Since we replaced the Tekton pipeline with the APL operator, we no longer need to push fake-commits for triggering an upgrade. However, since the branch never changes, the APL operator needs to become aware of the upstream changes. This PR changes the script to restart the pods.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
