### PR TITLE
fix: use single-instance cache for Gitea

### DIFF
--- a/values/gitea/gitea.gotmpl
+++ b/values/gitea/gitea.gotmpl
@@ -176,6 +176,10 @@ postgresql:
   enabled: false
 postgresql-ha:
   enabled: false
+redis-cluster:
+  enabled: false
+redis:
+  enabled: true
 
 extraContainerVolumeMounts:
   - name: backup


### PR DESCRIPTION
## 📌 Summary

Reconfigure Gitea to use single-instance Redis for reducing memory usage.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
