### PR TITLE
fix: barman compatibility with non-aws object storage

### DIFF
--- a/charts/otomi-db/templates/cluster.yaml
+++ b/charts/otomi-db/templates/cluster.yaml
@@ -38,6 +38,12 @@ spec:
   {{- toYaml . | nindent 2 }}
   {{- end }}
 {{- if .Values.backup.enabled }}
+  env:
+    # Barman object storage compatibility (https://github.com/EnterpriseDB/barman/issues/1086)
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: WHEN_REQUIRED
+    - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+      value: WHEN_REQUIRED
   {{- if eq .Values.backup.type "minioLocal" }}
   backup:
     retentionPolicy: {{ .Values.backup.retentionPolicy }}

--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -1233,6 +1233,7 @@ environments:
           keycloak:
             imageName: null
             size: 5Gi
+            walStorageSize: 5Gi
             replicas: 2
             recovery: {}
             externalClusters: []
@@ -1246,6 +1247,7 @@ environments:
           harbor:
             imageName: null
             size: 5Gi
+            walStorageSize: 5Gi
             replicas: 2
             coreDatabase: registry
             recovery: {}
@@ -1260,6 +1262,7 @@ environments:
           gitea:
             imageName: null
             size: 5Gi
+            walStorageSize: 5Gi
             replicas: 2
             recovery: {}
             externalClusters: []

--- a/values-schema.yaml
+++ b/values-schema.yaml
@@ -3310,6 +3310,8 @@ properties:
         properties:
           size:
             type: string
+          walStorageSize:
+            type: string
           resources:
             $ref: '#/definitions/resources'
           replicas:
@@ -3330,6 +3332,8 @@ properties:
         properties:
           size:
             type: string
+          walStorageSize:
+            type: string
           resources:
             $ref: '#/definitions/resources'
           replicas:
@@ -3349,6 +3353,8 @@ properties:
         title: gitea
         properties:
           size:
+            type: string
+          walStorageSize:
             type: string
           resources:
             $ref: '#/definitions/resources'

--- a/values/gitea/gitea-otomi-db.gotmpl
+++ b/values/gitea/gitea-otomi-db.gotmpl
@@ -8,6 +8,8 @@
 name: gitea-db
 storage:
   size: {{ $gdb.size }}
+walStorage:
+  size: {{ $gdb.walStorageSize }}
 instances: {{ $gdb.replicas }}
 
 {{- with $gdb.imageName }}

--- a/values/harbor/harbor-otomi-db.gotmpl
+++ b/values/harbor/harbor-otomi-db.gotmpl
@@ -7,6 +7,8 @@
 name: harbor-otomi-db
 storage:
   size: {{ $hdb.size }}
+walStorage:
+  size: {{ $hdb.walStorageSize }}
 instances: {{ $hdb.replicas }}
 
 {{- with $hdb.imageName }}

--- a/values/keycloak/keycloak-otomi-db.gotmpl
+++ b/values/keycloak/keycloak-otomi-db.gotmpl
@@ -8,6 +8,8 @@
 name: keycloak-db
 storage:
   size: {{ $kdb.size }}
+walStorage:
+  size: {{ $kdb.walStorageSize }}
 instances: {{ $kdb.replicas }}
 
 {{- with $kdb.imageName }}


### PR DESCRIPTION
## 📌 Summary

This fixes the critical issue of CloudnativePG backups failing to upload to Linode Object Storage, eventually resulting in full volumes.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
