### PR TITLE
fix: status code evaluation from k8s client

### DIFF
--- a/src/cmd/migrate.ts
+++ b/src/cmd/migrate.ts
@@ -19,6 +19,7 @@ import { parse } from 'yaml'
 import { Argv } from 'yargs'
 import { $, cd } from 'zx'
 import { k8s } from '../common/k8s'
+import { ApiException } from '@kubernetes/client-node'
 
 const cmdName = getFilename(__filename)
 
@@ -449,7 +450,7 @@ const checkExists = async (func: () => Promise<any>): Promise<boolean> => {
     await func()
     return true
   } catch (error) {
-    if (error.code === 404) {
+    if (error instanceof ApiException && error.code === 404) {
       return false
     } else {
       throw error

--- a/src/cmd/migrate.ts
+++ b/src/cmd/migrate.ts
@@ -449,7 +449,7 @@ const checkExists = async (func: () => Promise<any>): Promise<boolean> => {
     await func()
     return true
   } catch (error) {
-    if (error.response && error.response.statusCode === 404) {
+    if (error.code === 404) {
       return false
     } else {
       throw error


### PR DESCRIPTION
## 📌 Summary

This PR fixes an issue caused by changes in the Kubernetes API client, returning a different structure of the response. Without it, it fails to install APL operator and leaves the platform in a broken state.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
