### PR TITLE
fix: prerelease versions in upgrade check

### DIFF
--- a/src/cmd/upgrade.test.ts
+++ b/src/cmd/upgrade.test.ts
@@ -17,9 +17,15 @@ describe('filterUpgrades', () => {
 
 describe('filterUpgrades RC version', () => {
   it('should filter out lower versions', () => {
-    const inputData = [{ version: '2.1.0' }, { version: '2.1.1' }]
-    const expectedData = [{ version: '2.1.0' }, { version: '2.1.1' }]
+    const inputData = [{ version: '2.1.0' }, { version: '2.1.1' }, { version: '2.1.2' }]
+    const expectedData = [{ version: '2.1.1' }, { version: '2.1.2' }]
 
     expect(upgrade.filterUpgrades('2.1.1-rc.1', inputData)).toEqual(expectedData)
+  })
+  it('should consider prerelease without patch number', () => {
+    const inputData = [{ version: '2.0.0' }, { version: '2.1.0' }, { version: '2.2.0' }]
+    const expectedData = [{ version: '2.1.0' }, { version: '2.2.0' }]
+
+    expect(upgrade.filterUpgrades('2.1-rc1', inputData)).toEqual(expectedData)
   })
 })

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -26,18 +26,6 @@ describe('Flatten objects', () => {
   })
 })
 
-describe('semverCompare', () => {
-  it('should indicate version to be higher', () => {
-    expect(utils.semverCompare('1.1.3', '0.1.1')).toEqual(1)
-  })
-  it('should indicate version to be equal', () => {
-    expect(utils.semverCompare('0.1.1', '0.1.1')).toEqual(0)
-  })
-  it('should indicate version to be lower', () => {
-    expect(utils.semverCompare('0.1.1', '1.1.3')).toEqual(-1)
-  })
-})
-
 describe('ensureTeamGitopsDirectories', () => {
   it('should create .gitkeep files in all team directories', async () => {
     const envDir = '/values'

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -182,24 +182,6 @@ const isCoreCheck = (): boolean => {
 
 export const isCore: boolean = isCoreCheck()
 
-/**
- * Compare semver version strings, returning -1, 0, or 1.
- * If the semver string a is greater than b, return 1. If the semver string b is greater than a, return -1. If a equals b, return 0
- */
-export const semverCompare = (a, b) => {
-  const pa = a.split('.')
-  const pb = b.split('.')
-  for (let i = 0; i < 3; i++) {
-    const na = Number(pa[i])
-    const nb = Number(pb[i])
-    if (na > nb) return 1
-    if (nb > na) return -1
-    if (!Number.isNaN(na) && Number.isNaN(nb)) return 1
-    if (Number.isNaN(na) && !Number.isNaN(nb)) return -1
-  }
-  return 0
-}
-
 export const getSchemaSecretsPaths = async (teams: string[]): Promise<string[]> => {
   const schema: any = await getValuesSchema()
   const leaf = 'x-secret'


### PR DESCRIPTION
## 📌 Summary

This PR fixes the version filter that checks for relevant upgrade scripts based on the platform version number (i.e. regardless of the values, which are handled by migrations). It also replaces a custom version check with the `semver` library. This makes version syntax more strict, but easier to discover errors.

## 🔍 Reviewer Notes

An existing test was altered. An upgrade from version `2.1.1-rc.1` should include upgrades for `2.1.1`, but not `2.1.0`.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
