### PR TITLE
fix: prerelease versions in upgrade check

### DIFF
--- a/src/cmd/upgrade.test.ts
+++ b/src/cmd/upgrade.test.ts
@@ -26,6 +26,6 @@ describe('filterUpgrades RC version', () => {
     const inputData = [{ version: '2.0.0' }, { version: '2.1.0' }, { version: '2.2.0' }]
     const expectedData = [{ version: '2.1.0' }, { version: '2.2.0' }]
 
-    expect(upgrade.filterUpgrades('2.1-rc1', inputData)).toEqual(expectedData)
+    expect(upgrade.filterUpgrades('2.1-rc.1', inputData)).toEqual(expectedData)
   })
 })

--- a/src/cmd/upgrade.ts
+++ b/src/cmd/upgrade.ts
@@ -37,7 +37,7 @@ export type Upgrades = Array<Upgrade>
 // select upgrades after semver version, and always select upgrade with version "dev" for dev purposes
 export function filterUpgrades(version: string, upgrades: Upgrades): Upgrades {
   // Prereleases such as v1.0-rc1 are not a complete semantic version - changing these to v1.0.0-rc1
-  const prereleaseMatch = version.match(/^[0-9]+\.[0-9]+(-[a-zA-Z]+[0-9]+)$/)
+  const prereleaseMatch = version.match(/^[0-9]+\.[0-9]+(-[a-zA-Z]+\.+[0-9]+)$/)
   const currentVersion = prereleaseMatch ? version.replace(prereleaseMatch[1], `.0${prereleaseMatch[1]}`) : version
   return upgrades.filter((c) => c.version === 'dev' || semver.gt(c.version, currentVersion))
 }

--- a/src/cmd/upgrade.ts
+++ b/src/cmd/upgrade.ts
@@ -37,7 +37,7 @@ export type Upgrades = Array<Upgrade>
 // select upgrades after semver version, and always select upgrade with version "dev" for dev purposes
 export function filterUpgrades(version: string, upgrades: Upgrades): Upgrades {
   // Prereleases such as v1.0-rc1 are not a complete semantic version - changing these to v1.0.0-rc1
-  const prereleaseMatch = version.match(/^[0-9]+\.[0-9]+(-[a-zA-Z]+\.+[0-9]+)$/)
+  const prereleaseMatch = version.match(/^[0-9]+\.[0-9]+(-[a-zA-Z]+\.?[0-9]+)$/)
   const currentVersion = prereleaseMatch ? version.replace(prereleaseMatch[1], `.0${prereleaseMatch[1]}`) : version
   return upgrades.filter((c) => c.version === 'dev' || semver.gt(c.version, currentVersion))
 }


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->
Fixes the rc version in the upgrade script. It now checks for `vX.X.X-rc.X` instead of `vX.X.X-rcX`
See: https://www.npmjs.com/package/standard-version#release-as-a-pre-release

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
