### PR TITLE
feat: implement restart functionality for otomi-api deployment

### DIFF
--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -5,7 +5,7 @@ import { cleanupHandler, prepareEnvironment } from 'src/common/cli'
 import { logLevelString, terminal } from 'src/common/debug'
 import { env } from 'src/common/envalid'
 import { hf, HF_DEFAULT_SYNC_ARGS } from 'src/common/hf'
-import { getDeploymentState, getHelmReleases, setDeploymentState } from 'src/common/k8s'
+import { getDeploymentState, getHelmReleases, k8s, restartOtomiApiDeployment, setDeploymentState } from 'src/common/k8s'
 import { getFilename, rootDir } from 'src/common/utils'
 import { getCurrentVersion, getImageTag, writeValuesToFile } from 'src/common/values'
 import { getParsedArgs, HelmArguments, helmOptions, setParsedArgs } from 'src/common/yargs'
@@ -127,6 +127,7 @@ const applyAll = async () => {
       const initialData = await initialSetupData()
       await createCredentialsSecret(initialData.secretName, initialData.username, initialData.password)
       await retryIsOAuth2ProxyRunning()
+      await restartOtomiApiDeployment(k8s.app())
       await printWelcomeMessage(initialData.secretName, initialData.domainSuffix)
     }
   }

--- a/src/common/k8s.ts
+++ b/src/common/k8s.ts
@@ -531,7 +531,8 @@ export async function restartOtomiApiDeployment(appApi: AppsV1Api): Promise<void
 
   try {
     d.info('Restarting otomi-api deployment')
-
+    // This is equivalent to the 'kubectl rollout restart' command/
+    // Read more at: https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-k8s-io-restart-at
     await appApi.patchNamespacedDeployment(
       {
         name: 'otomi-api',


### PR DESCRIPTION
## 📌 Summary
- restart otomi-api after installation is finished.
<!-- What does this PR do? Why is it needed? -->

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
