### PR TITLE
fix: always deploy tekton and apl related namespaces

### DIFF
--- a/core.yaml
+++ b/core.yaml
@@ -29,6 +29,8 @@ k8s:
     - name: gitea
     - name: apl-gitea-operator
       disableIstioInjection: true
+    - name: apl-operator
+      disableIstioInjection: true
     - name: grafana
       app: grafana
     - name: istio-system
@@ -71,11 +73,9 @@ k8s:
       disableIstioInjection: true
       disablePolicyChecks: true
     - name: tekton-pipelines
-      app: tekton
       disableIstioInjection: true
       disablePolicyChecks: true
     - name: tekton-triggers
-      app: tekton
       disableIstioInjection: true
       disablePolicyChecks: true
     - name: otel


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->

## 🔍 Reviewer Notes

By removing the `app: tekton` label we instruct APL to always deploy those namespaces.
For the sake of consistency we also ensure that `apl-operator` is deployed in the same way

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
