### PR TITLE
ci: oauth2-proxy chart source

### DIFF
--- a/chart/chart-index/Chart.yaml
+++ b/chart/chart-index/Chart.yaml
@@ -76,7 +76,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
   - name: oauth2-proxy
     version: 7.7.24
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://oauth2-proxy.github.io/manifests
   - name: opentelemetry-operator
     alias: otel-operator
     version: 0.33.0


### PR DESCRIPTION
## 📌 Summary

The chart reference for OAuth2-Proxy is not set to the source we are actually using. Therefore, we are not getting any automated upgrades. Neither would the upgrades work correctly, since the referenced chart has a different structure.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
