### PR TITLE
feat: set custom repository and use selectors on argocd applications

### DIFF
--- a/src/cmd/apply-as-apps.ts
+++ b/src/cmd/apply-as-apps.ts
@@ -12,6 +12,7 @@ import { getParsedArgs, HelmArguments, helmOptions, setParsedArgs } from 'src/co
 import { Argv, CommandModule } from 'yargs'
 import { $ } from 'zx'
 import { V1ResourceRequirements } from '@kubernetes/client-node'
+import { env } from '../common/envalid'
 
 const cmdName = getFilename(__filename)
 const dir = '/tmp/otomi'
@@ -44,7 +45,7 @@ const getAppName = (release: HelmRelease): string => {
   return `${release.namespace}-${release.name}`
 }
 
-const getArgocdAppManifest = (release: HelmRelease, values: Record<string, any>, otomiVersion) => {
+const getArgocdAppManifest = (release: HelmRelease, values: Record<string, any>, otomiVersion: string) => {
   const name = getAppName(release)
   const patch = appPatches[name] || genericPatch
   return {
@@ -72,8 +73,8 @@ const getArgocdAppManifest = (release: HelmRelease, values: Record<string, any>,
       project: 'default',
       source: {
         path: release.chart.replace('../', ''),
-        repoURL: 'https://github.com/linode/apl-core.git',
-        targetRevision: otomiVersion,
+        repoURL: env.APPS_REPO_URL,
+        targetRevision: env.APPS_REVISION || otomiVersion,
         helm: {
           releaseName: release.name,
           values: objectToYaml(values),

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -163,15 +163,19 @@ const apply = async (): Promise<void> => {
   }
   d.info('Start apply')
   const skipCleanup = argv.skipCleanup ? '--skip-cleanup' : ''
-  await hf(
-    {
-      fileOpts: argv.file,
-      labelOpts: argv.label,
-      logLevel: logLevelString(),
-      args: ['apply', '--include-needs', skipCleanup],
-    },
-    { streams: { stdout: d.stream.log, stderr: d.stream.error } },
-  )
+  if (argv.tekton) {
+    await applyAsApps(argv)
+  } else {
+    await hf(
+      {
+        fileOpts: argv.file,
+        labelOpts: argv.label,
+        logLevel: logLevelString(),
+        args: ['apply', '--include-needs', skipCleanup],
+      },
+      { streams: { stdout: d.stream.log, stderr: d.stream.error } },
+    )
+  }
 }
 
 export const module: CommandModule = {

--- a/src/common/envalid.ts
+++ b/src/common/envalid.ts
@@ -35,6 +35,14 @@ export const cliEnvSpec = {
   GIT_URL: str({ default: 'gitea-http.gitea.svc.cluster.local' }),
   GIT_PORT: str({ default: '3000' }),
   GIT_PROTOCOL: str({ default: 'http' }),
+  APPS_REPO_URL: str({
+    desc: 'Repository to set for ArgoCD applications',
+    default: 'https://github.com/linode/apl-core.git',
+  }),
+  APPS_REVISION: str({
+    desc: 'Target revision to set for ArgoCD applications. If not set, uses the current image tag.',
+    default: undefined,
+  }),
 }
 
 export function cleanEnv<T>(spec: { [K in keyof T]: ValidatorSpec<T[K]> }, options?: CleanOptions<T>) {


### PR DESCRIPTION
## 📌 Summary

This PR adds two features to the `otomi apply` command:
* There are two environment variables, `APPS_REPO_URL` and `APPS_REVISION`, which allow configuring the `repoURL` and `targetRevision` of ArgoCD application manifests when using `otomi apply-as-apps` or `otomi apply --tekton`. This way, feature branches can be pushed to other locations than the public GitHub repo for experimental purposes.
* `otomi apply --tekton` supports selectors, e.g. by file or name, for selectively configuring the ArgoCD applications.

These two come in useful when testing a new version of an app, without pushing all incremental changes to GitHub. Also, using the selectors, it does not keep re-enabling `apl-operator`, reverting any potential changes sent from a local Otomi CLI. Application upgrades can be tested on top of different releases, e.g. `main` and the previous release, without creating a separate feature branch for each combination.

Example, which only updates a single app with a new chart (provided that the Core repo was mirrored to the cluster):

```
APPS_REPO_URL=https://gitea.mycluster.dev-akamai-apl.net/otomi/core.git APPS_REVISION=testing-chart-branch otomi apply -l pkg=testing-chart --tekton
```

## 🔍 Reviewer Notes

These changes are for development use. Without setting any environment variables or selectors, they should not affect the behavior of the apl-operator.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
