### PR TITLE
fix: add CloudFirewall rule for prometheus-node-exporter

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -295,6 +295,9 @@ jobs:
           helm install cloud-firewall-crd linode-cfw/cloud-firewall-crd \
             && kubectl wait --for condition=established --timeout=60s crd/cloudfirewalls.networking.linode.com \
             && helm install cloud-firewall-ctrl linode-cfw/cloud-firewall-controller
+            && kubectl wait --for=create -n kube-system cloudfirewalls.networking.linode.com/primary \
+            && kubectl wait --for=jsonpath='{.status.firewall-id}' -n kube-system cloudfirewalls.networking.linode.com/primary \
+            && kubectl patch cloudfirewall -n kube-system primary --type='json' --patch '[{"op":"add","path":"/spec/ruleset/inbound/-","value":{"label":"allow-prometheus-node-export-tcp","action":"ACCEPT","description":"Prometheus Node Exporter","protocol":"TCP","ports":"9100","addresses":{"ipv4":["192.168.128.0/17"]}}}]'
       - name: APL install
         if: ${{ inputs.install_profile != 'no-apl' }}
         env:


### PR DESCRIPTION
## 📌 Summary

This PR adds a rule for the Linode Cloud Firewall for integration test installs, allowing inbound traffic from the cluster network required to retrieve data from the Prometheus Node Exporter.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
