### PR TITLE
feat: enabling ORCS by default

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -1319,7 +1319,7 @@ environments:
           isMultitenant: true
           nodeSelector: {}
           isPreInstalled: false
-          useORCS: false
+          useORCS: true
         users: []
         e2e:
           enabled: false


### PR DESCRIPTION
This PR enabled the use of ORCS by default after tekton images were moved to new (not working at the moment) registry (ghcr.io)