### PR TITLE
feat: making linode provider an ORCS dependency

### DIFF
--- a/helmfile.d/snippets/derived.gotmpl
+++ b/helmfile.d/snippets/derived.gotmpl
@@ -76,7 +76,7 @@ environments:
   default:
     values:
       - _derived: # < introduced to hold compound logic in meaningful prop names for easier consumption
-          buildStorageClassName: {{ if eq $v.cluster.provider "linode" }}"linode-block-storage"{{ else }}""{{ end }} 
+          buildStorageClassName: {{ if eq $v.cluster.provider "linode" }}"linode-block-storage"{{ else }}""{{ end }}
           caCert: |
             {{- if eq $issuer "letsencrypt" }}
             -----BEGIN CERTIFICATE-----
@@ -259,6 +259,6 @@ environments:
           {{- end }}
         otomi:
           version: {{ $otomiTag }}
-          linodeLkeImageRepository: {{ if $v.otomi.useORCS }}mirror.registry.linodelke.net{{ end }}
+          linodeLkeImageRepository: {{ if and $v.otomi.useORCS (eq $provider "linode") }}mirror.registry.linodelke.net{{ end }}
         versions: {{- $versions | toYaml | nindent 10 }}
       - ../core.yaml


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->

This provider allows enabling ORCS only when the cluster.provider is linode. Otherwise the useORCS flag will have no effect. 

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
