### PR TITLE
feat: reverting ORCS migration for upgraded clusters

### DIFF
--- a/helmfile.d/snippets/defaults.yaml
+++ b/helmfile.d/snippets/defaults.yaml
@@ -1452,4 +1452,4 @@ environments:
             version: main
         # TODO: update this when schema version changes
         versions:
-          specVersion: 44
+          specVersion: 43

--- a/tests/fixtures/env/settings/versions.yaml
+++ b/tests/fixtures/env/settings/versions.yaml
@@ -3,4 +3,4 @@ metadata:
     name: versions
     labels: {}
 spec:
-    specVersion: 44
+    specVersion: 43

--- a/values-changes.yaml
+++ b/values-changes.yaml
@@ -375,6 +375,3 @@ changes:
   - version: 43
     deletions:
       - 'apps.harbor.resources.chartmuseum'
-  - versions: 44
-    mutations:
-      - otomi.useORCS: true


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->
We decided to not migrate current clusters to use ORCS automatically but let the user do so if needed through the values repository by changing the `useORCS` flag in the `otomi.yaml` file.
## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
