### PR TITLE
fix: net-istio-webhook image override

### DIFF
--- a/values/knative-serving/knative-serving-cr.gotmpl
+++ b/values/knative-serving/knative-serving-cr.gotmpl
@@ -20,7 +20,7 @@ spec:
       migrate: "{{ $v.otomi.linodeLkeImageRepository }}/gcr/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate:{{ $tag }}"
       cleanup: "{{ $v.otomi.linodeLkeImageRepository }}/gcr/knative-releases/knative.dev/serving/pkg/cleanup/cmd/cleanup:{{ $tag }}"
       net-istio-controller/controller: "{{ $v.otomi.linodeLkeImageRepository }}/gcr/knative-releases/knative.dev/net-istio/cmd/controller:{{ $netIstioTag }}"
-      net-istio-controller/webhook: "{{ $v.otomi.linodeLkeImageRepository }}/gcr/knative-releases/knative.dev/net-istio/cmd/webhook:{{ $netIstioTag }}"
+      net-istio-webhook/webhook: "{{ $v.otomi.linodeLkeImageRepository }}/gcr/knative-releases/knative.dev/net-istio/cmd/webhook:{{ $netIstioTag }}"
   {{- end }}
   version: "{{ $knativeServingVersion }}"
   {{- if $v._derived.untrustedCA }}


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->
This PR fixes a typo in the `net-istio-controller/webhook` image override in the knativeserving CR. See examples: https://knative.dev/docs/install/operator/configuring-serving-cr/#download-images-individually-without-secrets

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
