### PR TITLE
fix: handle merge conflicts in apl-operator

### DIFF
--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -33,6 +33,30 @@ interface InitialData {
   secretName: string
 }
 
+const isConflictError = (error: any): boolean => {
+  const errorMsg = error?.message?.toLowerCase() || ''
+  return (
+    errorMsg.includes('failed to merge') ||
+    errorMsg.includes('resolve your current index first') ||
+    errorMsg.includes('you need to resolve') ||
+    errorMsg.includes('merge conflict')
+  )
+}
+
+const cleanupGitState = async (d: any): Promise<void> => {
+  try {
+    cd(env.ENV_DIR)
+    // Try to abort any ongoing merge or rebase
+    await $`git merge --abort`.nothrow().quiet()
+    await $`git rebase --abort`.nothrow().quiet()
+    // Reset to the commit before our failed commit to discard local changes
+    await $`git reset --hard HEAD~1`.quiet()
+    d.info('Git state cleaned up after conflict - local commit discarded, reconciliation will retry')
+  } catch (cleanupError) {
+    d.warn('Error during git cleanup:', cleanupError?.message)
+  }
+}
+
 const commitAndPush = async (values: Record<string, any>, branch: string): Promise<void> => {
   const d = terminal(`cmd:${cmdName}:commitAndPush`)
   d.info('Committing values')
@@ -76,7 +100,7 @@ const commitAndPush = async (values: Record<string, any>, branch: string): Promi
         let remoteBranchExists = true
         try {
           await $`git ls-remote --exit-code --heads origin ${branch}`.quiet()
-        } catch (e) {
+        } catch {
           remoteBranchExists = false
         }
         // We're not always sure that we are on the correct branch,
@@ -89,9 +113,19 @@ const commitAndPush = async (values: Record<string, any>, branch: string): Promi
           d.log(`Remote branch '${branch}' does not exist. Skipping pull.`)
         }
         await $`git push -u origin ${branch}`.quiet()
-      } catch (e) {
+      } catch (pullPushError) {
+        // Check if this is a merge conflict - if so, skip the commit
+        if (isConflictError(pullPushError)) {
+          d.warn(
+            'Merge conflict detected during pull/push. Cleaning up and skipping commit - reconciliation will retry.',
+          )
+          await cleanupGitState(d)
+          return // Exit successfully, letting reconciliation handle the retry
+        }
+
+        // For other errors, continue with retry logic
         const errorMsg = 'Could not pull and push. Retrying...'
-        d.error(errorMsg, e?.message?.replace(password, '****'))
+        d.error(errorMsg, pullPushError?.message?.replace(password, '****'))
         throw new Error(errorMsg)
       }
     },

--- a/src/cmd/gen-drone.ts
+++ b/src/cmd/gen-drone.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { terminal } from 'src/common/debug'
 import { getFilename } from 'src/common/utils'
 import { BasicArguments } from 'src/common/yargs'

--- a/src/common/debug.ts
+++ b/src/common/debug.ts
@@ -17,7 +17,6 @@ export class DebugStream extends Writable {
     this.output = output
   }
 
-  // eslint-disable-next-line no-underscore-dangle,@typescript-eslint/explicit-module-boundary-types
   _write(chunk: any, encoding: any, callback: (error?: Error | null) => void): void {
     const data = chunk.toString().trim()
     if (data.length > 0) this.output(data)
@@ -59,7 +58,7 @@ export const terminal = (namespace: string): OtomiDebugger => {
     }
     return cons
   }
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
+
   const noop = () => {}
   const base = (...args: any[]) => createDebugger(`${namespace}`).call(undefined, ...args)
   const log = (...args: any[]) => createDebugger(`${namespace}:log`).call(undefined, ...args)
@@ -114,7 +113,7 @@ let logLevelVar = Number.NEGATIVE_INFINITY
  * - Environment variable: TRACE  [(un)set]
  * @returns highest loglevel
  */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+
 export const logLevel = (argv?: any): number => {
   let logLevelNum = Number(logLevels[argv?.logLevel?.toUpperCase() ?? 'INFO'])
   const verbosity = Number(argv?.verbose ?? 0)

--- a/src/common/zx-enhance.ts
+++ b/src/common/zx-enhance.ts
@@ -41,7 +41,7 @@ export const ask = async (query: string, options?: AskType, deps = { getParsedAr
   let answer = ''
   let tries = 0
   let matches = false
-  /* eslint-disable no-await-in-loop */
+
   do {
     answer = await deps.question(`${query}\n> `, { choices })
     matches = await matchingFn(answer)
@@ -49,7 +49,7 @@ export const ask = async (query: string, options?: AskType, deps = { getParsedAr
     if (answer?.length === 0 && defaultAnswer.length > 0) return defaultAnswer
     if (tries >= maxRetries) throw new Error(`Max retries for: ${chalk.italic(query)}`)
   } while (answer.length <= 0 || !matches)
-  /* eslint-enable no-await-in-loop */
+
   return answer
 }
 

--- a/src/operator/k8s.ts
+++ b/src/operator/k8s.ts
@@ -70,7 +70,7 @@ export async function updateApplyState(
       }
     }
 
-    d.info(`Apply state updated successfully for commit ${state.commitHash}`)
+    d.info(`Apply state updated for commit ${state.commitHash}`)
   } catch (error) {
     d.error('Failed to update apply state:', getErrorMessage(error))
   }

--- a/src/test-init.ts
+++ b/src/test-init.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {}
 
 export const beforeAll = (): void => {


### PR DESCRIPTION
## 📌 Summary

apl-core also commits to Gitea. This can cause for merge conflicts in the apl-operator when changes are really fast after each other.
The way we handle it now is that we will just reset the commit apl-core made and let it resolve in the next apply loop. So if there are conflicts it will reset the commit and not push anything. The reconciliation loop wil add the next commit
## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
