### PR TITLE
fix: push apl-charts repository with tag

### DIFF
--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -166,8 +166,8 @@ export const cloneOtomiChartsInGitea = async (): Promise<void> => {
     await $`git tag ${tag}`
     await $`git remote add origin ${giteaChartsUrl}`
     await $`git config http.sslVerify false`
-    await $`git push -u origin heads/main`.quiet()
-    await $`git push origin tags/${tag}`.quiet()
+    await $`git push -u origin refs/heads/main`.quiet()
+    await $`git push origin refs/tags/${tag}`.quiet()
   } catch (error) {
     d.info('cloneOtomiChartsInGitea Error ', error?.message?.replace(password, '****'))
   }

--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -166,7 +166,7 @@ export const cloneOtomiChartsInGitea = async (): Promise<void> => {
     await $`git tag ${tag}`
     await $`git remote add origin ${giteaChartsUrl}`
     await $`git config http.sslVerify false`
-    await $`git push -u origin main`.quiet()
+    await $`git push -u origin heads/main`.quiet()
     await $`git push origin tags/${tag}`.quiet()
   } catch (error) {
     d.info('cloneOtomiChartsInGitea Error ', error?.message?.replace(password, '****'))

--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -158,15 +158,15 @@ export const cloneOtomiChartsInGitea = async (): Promise<void> => {
     await $`rm -rf .vscode`
     await $`rm -f .gitignore`
     await $`rm -f LICENSE`
-    await $`git init --initial-branch=main`
+    await $`git init`
     await setIdentity(username, email)
     await $`git add .`
     await $`git commit -m "first commit for tag ${tag}"`
     await $`git tag ${tag}`
     await $`git remote add origin ${giteaChartsUrl}`
     await $`git config http.sslVerify false`
-    await $`git push -u origin main`.quiet()
-    await $`git push origin ${tag}`.quiet()
+    await $`git push -u origin heads/main`.quiet()
+    await $`git push origin tags/${tag}`.quiet()
   } catch (error) {
     d.info('cloneOtomiChartsInGitea Error ', error?.message?.replace(password, '****'))
   }

--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -162,10 +162,11 @@ export const cloneOtomiChartsInGitea = async (): Promise<void> => {
     await setIdentity(username, email)
     await $`git add .`
     await $`git commit -m "first commit for tag ${tag}"`
+    await $`git branch -M main`
     await $`git tag ${tag}`
     await $`git remote add origin ${giteaChartsUrl}`
     await $`git config http.sslVerify false`
-    await $`git push -u origin heads/main`.quiet()
+    await $`git push -u origin main`.quiet()
     await $`git push origin tags/${tag}`.quiet()
   } catch (error) {
     d.info('cloneOtomiChartsInGitea Error ', error?.message?.replace(password, '****'))

--- a/src/cmd/commit.ts
+++ b/src/cmd/commit.ts
@@ -149,7 +149,7 @@ export const cloneOtomiChartsInGitea = async (): Promise<void> => {
     }
     d.info(`Cloning apl-charts at tag '${tag}' from upstream`)
     await $`mkdir -p ${workDir}`
-    await $`git clone --branch ${tag} --depth 1 ${otomiChartsUrl} ${workDir}`
+    await $`git clone --branch ${tag} --depth 1 ${otomiChartsUrl} ${workDir}`.quiet()
     cd(workDir)
     await $`rm -rf .git`
     await $`rm -rf deployment`
@@ -158,16 +158,15 @@ export const cloneOtomiChartsInGitea = async (): Promise<void> => {
     await $`rm -rf .vscode`
     await $`rm -f .gitignore`
     await $`rm -f LICENSE`
-    await $`git init`
+    await $`git init --initial-branch=main`
     await setIdentity(username, email)
-    await $`git checkout -b main`
     await $`git add .`
     await $`git commit -m "first commit for tag ${tag}"`
     await $`git tag ${tag}`
     await $`git remote add origin ${giteaChartsUrl}`
     await $`git config http.sslVerify false`
-    await $`git push -u origin main`
-    await $`git push origin ${tag}`
+    await $`git push -u origin main`.quiet()
+    await $`git push origin ${tag}`.quiet()
   } catch (error) {
     d.info('cloneOtomiChartsInGitea Error ', error?.message?.replace(password, '****'))
   }


### PR DESCRIPTION
## 📌 Summary

This PR fixes to push apl-charts repository with tag.

Ticket: https://jira.linode.com/browse/APL-1067

## 🔍 Reviewer Notes

- Create a cluster using the APL-1076 branch.
- After the first login, navigate to the Catalog page.
- Verify that all the default Helm charts are present from the Gitea charts repository.
- Verify that both the main branch and the main tag exist in the Gitea charts repository.

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
