### PR TITLE
chore: update version for runtime upgrade

### DIFF
--- a/src/common/runtime-upgrades/runtime-upgrades.ts
+++ b/src/common/runtime-upgrades/runtime-upgrades.ts
@@ -65,7 +65,7 @@ export const runtimeUpgrades: RuntimeUpgrades = [
     },
   },
   {
-    version: '4.10.0',
+    version: '4.11.0',
     applications: {
       'istio-system-istiod': {
         post: async () => {


### PR DESCRIPTION
## 📌 Summary

This PR updates the runtime upgrade version, as the Istio patch 1.26.3 is not being included in the 4.10 release of the platform.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
