### PR TITLE
fix: update apl-operator before other upgrades

### DIFF
--- a/src/cmd/apply.test.ts
+++ b/src/cmd/apply.test.ts
@@ -102,7 +102,7 @@ describe('Apply command', () => {
     mockDeps.getDeploymentState.mockResolvedValue({ status: 'deployed' })
     mockDeps.getCurrentVersion.mockResolvedValue('1.0.0')
     mockDeps.getImageTag.mockResolvedValue('v1.0.0')
-    mockDeps.applyAsApps.mockResolvedValue(undefined)
+    mockDeps.applyAsApps.mockResolvedValue(true)
     mockDeps.commit.mockResolvedValue(undefined)
     mockDeps.upgrade.mockResolvedValue(undefined)
     mockDeps.runtimeUpgrade.mockResolvedValue(undefined)

--- a/src/cmd/apply.ts
+++ b/src/cmd/apply.ts
@@ -46,10 +46,14 @@ export const applyAll = async () => {
   // We still need to deploy all teams because some settings depend on platform apps.
   // Note that team-ns-admin contains ingress for platform apps.
   const params = cloneDeep(argv)
-  await applyAsApps(params)
+  const applyCompleted = await applyAsApps(params)
 
-  await upgrade({ when: 'post' })
-  await runtimeUpgrade({ when: 'post' })
+  if (applyCompleted) {
+    await upgrade({ when: 'post' })
+    await runtimeUpgrade({ when: 'post' })
+  } else {
+    d.info('Apply step not completed, skipping upgrade checks')
+  }
 
   if (!(env.isDev && env.DISABLE_SYNC)) {
     await commit(false)


### PR DESCRIPTION
## 📌 Summary

With this change, the apl-operator checks its own ArgoCD application against the desired version extracted from the values repository. If the revision does not match, it updates itself and awaits a restart with the new version.

This fixes issues with the ArgoCD apps revisions, referring to the charts from this GitHub repository, not matching the values brought along by the apl-operator image.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
