### PR TITLE
fix: storage configuration for pipeline output artifacts

### DIFF
--- a/charts/kubeflow-pipelines/templates/configmaps.yaml
+++ b/charts/kubeflow-pipelines/templates/configmaps.yaml
@@ -1,6 +1,22 @@
 apiVersion: v1
 data:
-  defaultPipelineRoot: ""
+  defaultPipelineRoot: "s3://{{ .Values.objectStorage.bucket }}/v2/artifacts"
+  providers: |-
+    s3:
+      default:
+        {{- if eq .Values.objectStorage.type "minio" }}
+        endpoint: {{ .Values.objectStorage.endpoint }}:{{ .Values.objectStorage.port }}
+        {{- else }}
+        endpoint: {{ .Values.objectStorage.region }}.{{ .Values.objectStorage.endpoint }}:{{ .Values.objectStorage.port }}
+        {{- end }}
+        region: {{ .Values.objectStorage.region | quote }}
+        disableSSL: {{ not .Values.objectStorage.secure }}
+        credentials:
+          fromEnv: false
+          secretRef:
+            secretName: mlpipeline-minio-artifact
+            accessKeyKey: accesskey
+            secretKeyKey: secretkey
 kind: ConfigMap
 metadata:
   labels:
@@ -27,7 +43,7 @@ data:
   cacheNodeRestrictions: "false"
   cronScheduleTimezone: UTC
   dbType: mysql
-  defaultPipelineRoot: "minio://{{ .Values.objectStorage.bucket }}/v2/artifacts"
+  defaultPipelineRoot: "s3://{{ .Values.objectStorage.bucket }}/v2/artifacts"
   mysqlHost: ml-pipeline-mysql
   mysqlPort: "3306"
 kind: ConfigMap

--- a/charts/kubeflow-pipelines/templates/workflow-controller/configmap.yaml
+++ b/charts/kubeflow-pipelines/templates/workflow-controller/configmap.yaml
@@ -8,6 +8,7 @@ data:
       {{- else }}
       endpoint: {{ .Values.objectStorage.region }}.{{ .Values.objectStorage.endpoint }}:{{ .Values.objectStorage.port }}
       {{- end }}
+      region: {{ .Values.objectStorage.region | quote }}
       bucket: {{ .Values.objectStorage.bucket }}
       keyFormat: "artifacts/{{`{{workflow.name}}`}}/{{`{{workflow.creationTimestamp.Y}}`}}/{{`{{workflow.creationTimestamp.m}}`}}/{{`{{workflow.creationTimestamp.d}}`}}/{{`{{pod.name}}`}}"
       # insecure will disable TLS. Primarily used for minio installs not configured with TLS

--- a/charts/kubeflow-pipelines/values.yaml
+++ b/charts/kubeflow-pipelines/values.yaml
@@ -10,7 +10,7 @@ global:
 objectStorage:
   type: "linode"  # linode or minio
   endpoint: ""
-  region: ""
+  region: "us-east-1"
   bucket: ""
   port: 443
   secure: true


### PR DESCRIPTION
## 📌 Summary

This PR adjusts the configuration for the Kubeflow Pipelines launcher, which has a slightly different configuration structure. Also the "region" is mandatory to set, even if not used. This made it impossible sending pipeline artifacts to object storage.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
