### PR TITLE
fix: ensure that default storageClass is used by databases 

### DIFF
--- a/helmfile.d/snippets/defaults.gotmpl
+++ b/helmfile.d/snippets/defaults.gotmpl
@@ -29,8 +29,8 @@
 {{- end }}
 
 
-{{- $defaultStorageClass := "" }}
-{{- if eq $clusterProvider "linode" }}
+{{- $defaultStorageClass := $cluster | get "spec.defaultStorageClass" "" }}
+{{- if and (eq $clusterProvider "linode") (eq $defaultStorageClass "") }}
   {{- $defaultStorageClass = "linode-block-storage" }}
 {{- end }}
 


### PR DESCRIPTION
## 📌 Summary
Users that install the platform with custom configuration wants to set defaultStorageClass for all core apps.
This PR ensures that default storageClass is used by databases if those are without custom storageClass setting.

## 🔍 Reviewer Notes

in `tests/fixtures/env/settings/cluster.yaml`

set `    defaultStorageClass: linode-block-storage-encrypted` 
and run `bin/compare.sh` locally to see the effect.
## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
