### PR TITLE
fix: mount cache folder as volume

### DIFF
--- a/chart/apl/templates/deployment.yaml
+++ b/chart/apl/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
               mountPath: /secret
             - name: tmp
               mountPath: /tmp
+            - name: cache
+              mountPath: /home/app/.cache
             - name: git-config
               mountPath: /home/app/.gitconfig
               subPath: .gitconfig
@@ -105,6 +107,8 @@ spec:
         - name: otomi-values
           emptyDir: {}
         - name: tmp
+          emptyDir: {}
+        - name: cache
           emptyDir: {}
         - name: git-config
           configMap:

--- a/charts/apl-operator/templates/deployment.yaml
+++ b/charts/apl-operator/templates/deployment.yaml
@@ -92,6 +92,8 @@ spec:
               mountPath: /home/app/stack/env
             - name: tmp
               mountPath: /tmp
+            - name: cache
+              mountPath: /home/app/.cache
             - name: git-config
               mountPath: /home/app/.gitconfig
               subPath: .gitconfig
@@ -99,6 +101,8 @@ spec:
         - name: apl-values
           emptyDir: {}
         - name: tmp
+          emptyDir: {}
+        - name: cache
           emptyDir: {}
         - name: git-config
           configMap:


### PR DESCRIPTION
## 📌 Summary

Helm could not load plugins
```
app@apl-operator-795b95d697-tc9rt:~/stack$ helm version
level=WARN msg="failed to load plugin (ignoring)" plugin_yaml=/home/app/.local/share/helm/plugins/helm-diff/plugin.yaml error="failed to create plugin manager: failed to create wazero compilation cache: create directory /home/app/.cache/helm/wazero-build: mkdir /home/app/.cache: read-only file system"
level=WARN msg="failed to load plugin (ignoring)" plugin_yaml=/home/app/.local/share/helm/plugins/helm-secrets/plugin.yaml error="failed to create plugin manager: failed to create wazero compilation cache: create directory /home/app/.cache/helm/wazero-build: mkdir /home/app/.cache: read-only file system"
version.BuildInfo{Version:"v4.2.3", GitCommit:"43e8b7feece8beb0fcba47059ec9b522fd929a64", GitTreeState:"clean", GoVersion:"go1.26.5", KubeClientVersion:"v1.36"}
```

## 🔍 Reviewer Notes
After
```
app@apl-operator-5d549cfcd8-g59sm:~/stack$ helm version
version.BuildInfo{Version:"v4.2.3", GitCommit:"43e8b7feece8beb0fcba47059ec9b522fd929a64", GitTreeState:"clean", GoVersion:"go1.26.5", KubeClientVersion:"v1.36"}
app@apl-operator-5d549cfcd8-g59sm:~/stack$
```

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
