### PR TITLE
fix: rendering the external-dns and cert-manager settings

### DIFF
--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -120,9 +120,10 @@ resources:
         solvers:
           - selector: {}
             dns01:
-              {{- with $p | get "akamai" nil }}
+              {{- if hasKey $p "akamai" }}
+              {{- $akamai := index $p "akamai" }}
               akamai:
-                serviceConsumerDomain: {{ .host }}
+                serviceConsumerDomain: {{ $akamai.host }}
                 accessTokenSecretRef:
                   name: external-dns
                   key: access_token
@@ -133,69 +134,73 @@ resources:
                   name: external-dns
                   key: client_secret
               {{- end }}
-              {{- with $p | get "aws" nil }}
+              {{- if hasKey $p "aws" }}
+              {{- $aws := index $p "aws" }}
               route53:
-                {{- with . | get "credentials.accessKey" nil }}
+                {{- with $aws | get "credentials.accessKey" nil }}
                 accessKeyID: {{ . }}
                 {{- end }}
-                {{- if . | get "credentials.secretKey" nil }}
+                {{- if $aws | get "credentials.secretKey" nil }}
                 secretAccessKeySecretRef:
                   key: secret
                   name: external-dns
                 {{- end }}
-                region: {{ .region }}
-                {{- with . | get "role" nil }}
+                region: {{ $aws.region }}
+                {{- with $aws | get "role" nil }}
                 role: {{ . }}
                 {{- end }}
               {{- end }}
-              {{- with $p | get "azure" nil }}
+              {{- if hasKey $p "azure" }}
+              {{- $azure := index $p "azure" }}
               azureDNS:
-                resourceGroupName: {{ .resourceGroup }}
-                subscriptionID: {{ .subscriptionId }}
-                {{- if hasKey . "aadClientId" }}
-                tenantID: {{ .tenantId }}
-                clientID: {{ .aadClientId }}
+                resourceGroupName: {{ $azure.resourceGroup }}
+                subscriptionID: {{ $azure.subscriptionId }}
+                {{- if hasKey $azure "aadClientId" }}
+                tenantID: {{ $azure.tenantId }}
+                clientID: {{ $azure.aadClientId }}
                 {{- end }}
-                {{- with . | get "hostedZoneName" nil }}
+                {{- with $azure | get "hostedZoneName" nil }}
                 hostedZoneName: {{ . }}
                 {{- end }}
                 clientSecretSecretRef:
                   key: secret
                   name: external-dns
               {{- end }}
-              {{- with $p | get "azure-private-dns" nil }}
+              {{- if hasKey $p "azure-private-dns" }}
+              {{- $azurePrivateDns := index $p "azure-private-dns" }}
               azureDNS:
-                resourceGroupName: {{ .resourceGroup }}
-                subscriptionID: {{ .subscriptionId }}
-                {{- if hasKey . "aadClientId" }}
-                tenantID: {{ .tenantId }}
-                clientID: {{ .aadClientId }}
+                resourceGroupName: {{ $azurePrivateDns.resourceGroup }}
+                subscriptionID: {{ $azurePrivateDns.subscriptionId }}
+                {{- if hasKey $azurePrivateDns "aadClientId" }}
+                tenantID: {{ $azurePrivateDns.tenantId }}
+                clientID: {{ $azurePrivateDns.aadClientId }}
                 {{- end }}
-                {{- with . | get "hostedZoneName" nil }}
+                {{- with $azurePrivateDns | get "hostedZoneName" nil }}
                 hostedZoneName: {{ . }}
                 {{- end }}
                 clientSecretSecretRef:
                   key: secret
                   name: external-dns
               {{- end }}
-              {{- with $p | get "cloudflare" nil }}
+              {{- if hasKey $p "cloudflare" }}
+              {{- $cloudflare := index $p "cloudflare" }}
               cloudflare:
-                {{- with . | get "apiToken" nil }}
+                {{- with $cloudflare | get "apiToken" nil }}
                 apiTokenSecretRef:
                 {{- end }}
-                {{- with . | get "apiSecret" nil }}
+                {{- with $cloudflare | get "apiSecret" nil }}
                 apiKeySecretRef:
                 {{- end }}
                   key: secret
                   name: external-dns
               {{- end }}
-              {{- with $p | get "digitalocean" nil }}
+              {{- if hasKey $p "digitalocean" }}
               digitalocean:
                 tokenSecretRef:
                   key: secret
                   name: external-dns
               {{- end }}
-              {{- with $p | get "linode" nil }}
+              {{- if hasKey $p "linode" }}
               webhook:
                 solverName: "linode"
                 groupName: acme.slicen.me
@@ -203,15 +208,17 @@ resources:
                   secretKey: secret
                   secretName: external-dns
               {{- end }}
-              {{- with $p | get "google" nil }}
+              {{- if hasKey $p "google" }}
+              {{- $google := index $p "google" }}
               cloudDNS:
-                project: {{ .project }}
+                project: {{ $google.project }}
                 serviceAccountSecretRef:
                   key: secret
                   name: external-dns
               {{- end }}
-              {{- with $p | get "other" nil }}
-              {{- toYaml . | get "cert-manager" nindent 14 }}
+              {{- if hasKey $p "other" }}
+              {{- $other := index $p "other" }}
+              {{- toYaml ($other | get "cert-manager" dict) | nindent 14 }}
               {{- end }}
 {{- end }}
 {{- if eq $cm.issuer "byo-wildcard-cert" }}

--- a/values/cert-manager/cert-manager-raw.gotmpl
+++ b/values/cert-manager/cert-manager-raw.gotmpl
@@ -185,14 +185,15 @@ resources:
               {{- if hasKey $p "cloudflare" }}
               {{- $cloudflare := index $p "cloudflare" }}
               cloudflare:
-                {{- with $cloudflare | get "apiToken" nil }}
-                apiTokenSecretRef:
-                {{- end }}
-                {{- with $cloudflare | get "apiSecret" nil }}
+                {{- if hasKey $cloudflare "email" }}
                 apiKeySecretRef:
-                {{- end }}
                   key: secret
                   name: external-dns
+                {{- else }}
+                apiTokenSecretRef:
+                  key: secret
+                  name: external-dns
+                {{- end }}
               {{- end }}
               {{- if hasKey $p "digitalocean" }}
               digitalocean:

--- a/values/external-dns/external-dns.gotmpl
+++ b/values/external-dns/external-dns.gotmpl
@@ -43,7 +43,7 @@ extraArgs:
 {{- end }}
 
 
-{{- with $dns.provider | get "akamai" nil }}
+{{- if hasKey $dns.provider "akamai" }}
 provider:
   name: akamai
 env:
@@ -66,7 +66,7 @@ env:
       key: EXTERNAL_DNS_AKAMAI_CLIENT_SECRET
 {{- end }}
 
-{{- with $dns.provider | get "linode" nil }}
+{{- if hasKey $dns.provider "linode" }}
 provider:
   name: linode
 env:
@@ -77,7 +77,7 @@ env:
       key: LINODE_TOKEN
 {{- end }}
 
-{{- with $dns.provider | get "digitalocean" nil }}
+{{- if hasKey $dns.provider "digitalocean" }}
 provider:
   name: digitalocean
 env:
@@ -88,7 +88,7 @@ env:
       key: DO_TOKEN
 {{- end }}
 
-{{- with $dns.provider | get "cloudflare" nil }}
+{{- if hasKey $dns.provider "cloudflare" }}
 provider:
   name: cloudflare
 env:
@@ -113,12 +113,12 @@ env:
   {{- end }}
 {{- end }}
 
-{{- with $dns.provider | get "aws" nil }}
+{{- if hasKey $dns.provider "aws" }}
 provider:
   name: aws
 env:
 - name: AWS_DEFAULT_REGION
-  value: "{{ .region }}"
+  value: "{{ $dns.provider.aws.region }}"
 {{- with $dns.provider.aws | get "credentials" nil }}
 - name: AWS_ACCESS_KEY_ID
   valueFrom:
@@ -137,7 +137,7 @@ extraArgs:
 {{- end }}
 {{- end }}
 
-{{- with $dns.provider | get "azure" nil }}
+{{- if hasKey $dns.provider "azure" }}
 provider:
   name: azure
 env:
@@ -168,7 +168,7 @@ env:
       key: AZURE_CLIENT_SECRET
 {{- end }}
 
-{{- with $dns.provider | get "azure-private-dns" nil }}
+{{- if hasKey $dns.provider "azure-private-dns" }}
 provider:
   name: azure
 env:
@@ -199,7 +199,7 @@ env:
       key: AZURE_CLIENT_SECRET
 {{- end }}
 
-{{- with $dns.provider | get "google" nil }}
+{{- if hasKey $dns.provider "google" }}
 provider:
   name: google
 secretConfiguration:
@@ -208,7 +208,7 @@ secretConfiguration:
   subPath: service-account.json
 env:
 - name: GOOGLE_PROJECT
-  value: "{{ .project }}"
+  value: "{{ $dns.provider.google.project }}"
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /etc/secrets/service-account/service-account.json
 extraVolumes:
@@ -221,9 +221,9 @@ extraVolumeMounts:
   readOnly: true
 {{- end }}
 
-{{- with $dns.provider | get "other" nil }}
-provider: {{ .name }}
-{{ .name }}: {{- . | get "external-dns" | toYaml | nindent 2 }}
+{{- if hasKey $dns.provider "other" }}
+provider: {{ $dns.provider.other.name }}
+{{ $dns.provider.other.name }}: {{- $dns.provider.other | get "external-dns" | toYaml | nindent 2 }}
 {{- end }}
 
 deploymentStrategy:


### PR DESCRIPTION
## 📌 Summary

Since the secrets has been removed from the values structure the dns settings can be an empty object
```
kind: AplDns
metadata:
    name: dns
spec:
    domainFilters:
        - example.com
    policy: upsert-only
    provider:
        linode: {}
    zoneIdFilters: []
```

therefor the templating login cannot rely on the `with` statement and should consistently use the `hasKey` statement 


## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
