### PR TITLE
fix(argocd): prevent ESO from copying tracking-id annotation to argocd-secret

### DIFF
--- a/values/argocd/argocd-raw.gotmpl
+++ b/values/argocd/argocd-raw.gotmpl
@@ -139,6 +139,11 @@ resources:
       target:
         name: argocd-secret
         creationPolicy: Merge
+        # Empty template stops ESO from copying this ExternalSecret's
+        # argocd tracking-id annotation onto the shared argocd-secret
+        template:
+          mergePolicy: Merge
+          metadata: {}
       data:
         - secretKey: oidc.clientSecret
           remoteRef:


### PR DESCRIPTION
## 📌 Summary

<!-- What does this PR do? Why is it needed? -->

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
