### PR TITLE
fix: provide git credentials on first attempt

### DIFF
--- a/src/operator/git-repository.test.ts
+++ b/src/operator/git-repository.test.ts
@@ -120,6 +120,7 @@ describe('GitRepository', () => {
 
     beforeEach(() => {
       fs.existsSync.mockReturnValue(false)
+      mockGit.addConfig = jest.fn()
     })
 
     test('should clone repository successfully when repo does not exist', async () => {
@@ -136,8 +137,9 @@ describe('GitRepository', () => {
       expect(mockGit.clone).toHaveBeenCalledWith(
         'https://testuser:testpass@github.com:443/testorg/testrepo.git',
         '/tmp/repo',
-        ['-b', 'main'],
+        ['-b', 'main', '-c', 'http.proactiveAuth=basic'],
       )
+      expect(mockGit.addConfig).toHaveBeenCalledWith('http.proactiveAuth', 'basic')
       expect(fs.existsSync).toHaveBeenCalledWith('/tmp/repo/.git')
     })
 
@@ -166,6 +168,7 @@ describe('GitRepository', () => {
       expect(fs.existsSync).toHaveBeenCalledWith('/tmp/repo/.git')
       expect(mockGit.clone).not.toHaveBeenCalled()
       expect(mockGit.getRemotes).toHaveBeenCalledWith(true)
+      expect(mockGit.addConfig).toHaveBeenCalledWith('http.proactiveAuth', 'basic')
       expect(mockGit.remote).not.toHaveBeenCalled()
     })
 

--- a/src/operator/git-repository.test.ts
+++ b/src/operator/git-repository.test.ts
@@ -416,6 +416,10 @@ describe('GitRepository', () => {
       password: 'newpass',
     }
 
+    beforeEach(async () => {
+      mockGit.addConfig = jest.fn()
+    })
+
     test('should update authenticatedUrl and set new git remote', async () => {
       mockGit.remote.mockResolvedValue(undefined)
 
@@ -423,6 +427,7 @@ describe('GitRepository', () => {
 
       expect(gitRepository.authenticatedUrl).toBe(newConfig.authenticatedUrl)
       expect(mockGit.remote).toHaveBeenCalledWith(['set-url', 'origin', newConfig.authenticatedUrl])
+      expect(mockGit.addConfig).toHaveBeenCalledWith('http.proactiveAuth', 'basic')
     })
 
     test('should update branch when it changes', async () => {

--- a/src/operator/git-repository.ts
+++ b/src/operator/git-repository.ts
@@ -214,6 +214,7 @@ export class GitRepository {
       this.email = config.email
       this._config = config
       await setIdentity(this.username, this.email, this.repoPath)
+      await this.git.addConfig('http.proactiveAuth', 'basic')
       this.d.info('Git config reloaded successfully')
     } catch (error) {
       this.d.error('Failed to reload git config:', getErrorMessage(error))

--- a/src/operator/git-repository.ts
+++ b/src/operator/git-repository.ts
@@ -80,7 +80,12 @@ export class GitRepository {
     } else {
       this.d.info(`Cloning repository to ${this.repoPath}`)
       try {
-        await this.git.clone(this._config.authenticatedUrl, this.repoPath, ['-b', this.branch])
+        await this.git.clone(this._config.authenticatedUrl, this.repoPath, [
+          '-b',
+          this.branch,
+          '-c',
+          'http.proactiveAuth=basic',
+        ])
         this.d.info(`Repository cloned successfully`)
       } catch (error) {
         this.d.error('Failed to clone repository:', getErrorMessage(error))
@@ -88,6 +93,7 @@ export class GitRepository {
       }
     }
     await setIdentity(this.username, this.email, this.repoPath)
+    await this.git.addConfig('http.proactiveAuth', 'basic')
   }
 
   private async verifyAndFixOriginRemote(): Promise<void> {


### PR DESCRIPTION
## 📌 Summary

This PR configures the Git client of apl-operator to send credentials with requests right away, instead of reacting to a 401 response from the Git remote.
The configuration option is added on the initial "clone" command and then persisted in the local Git repo.

## 🔍 Reviewer Notes

<!-- Anything you'd like reviewers to focus on (e.g., tricky logic, edge cases)? -->

## 🧹 Checklist

- [ ] Code is readable, maintainable, and robust.
- [ ] Unit tests added/updated
